### PR TITLE
closed #10 docker composeの書き方を変更した 公開ポートをローカルで変更できるようにした

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# NGINXポート
+NGINX_PORT=80
+
+# DBポート
+DB_PORT=13306

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.env
 .data/**
 /.php-cs-fixer.cache

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,25 @@
 install:
 	cp ./api/.env.example ./api/.env && \
-	docker-compose run --rm web yarn install
-	docker-compose run --rm api sh -c 'composer install && php artisan key:generate'
-	docker-compose run --rm api chmod -R 777 storage
-	docker-compose up -d
+	docker compose run --rm web yarn install
+	docker compose run --rm api sh -c 'composer install && php artisan key:generate'
+	docker compose run --rm api chmod -R 777 storage
+	docker compose up -d
 setup:
 	@make migrate
 	@make seed
 migrate:
-	docker-compose exec api php artisan migrate
+	docker compose exec api php artisan migrate
 seed:
-	docker-compose exec api php artisan db:seed
+	docker compose exec api php artisan db:seed
 test:
 	@make test-api
 	@make test-web
 test-api:
-	docker-compose exec api php artisan test
+	docker compose exec api php artisan test
 test-web:
-	docker-compose exec web yarn test
+	docker compose exec web yarn test
 coverage:
-	docker-compose exec api ./vendor/bin/phpunit --coverage-html coverage
+	docker compose exec api ./vendor/bin/phpunit --coverage-html coverage
 package-install:
-	docker-compose run --rm web yarn install
-	docker-compose run --rm api composer install
+	docker compose run --rm web yarn install
+	docker compose run --rm api composer install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 install:
 	cp ./api/.env.example ./api/.env && \
+	cp ./.env.example ./.env && \
 	docker compose run --rm web yarn install
 	docker compose run --rm api sh -c 'composer install && php artisan key:generate'
 	docker compose run --rm api chmod -R 777 storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: docker/nginx/Dockerfile.dev
     ports:
-      - "80:80"
+      - "${NGINX_PORT:-80}:80"
     tty: true
     depends_on:
       - web
@@ -42,7 +42,7 @@ services:
       MYSQL_PASSWORD: 'secret'
       MYSQL_ROOT_PASSWORD: 'root'
     ports:
-      - 13306:3306
+      - "${DB_PORT:-13306}:3306"
     volumes:
       - ./.data:/var/lib/mysql
       - ./docker/db/init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
# 概要
Makefile中のdocker composeの書き方を推奨される書き方に変更しました。

公開ポートをローカルで変更できるようにしました。
プロジェクトルートの`.env.example`ファイルをコピーして`.env`として設置してください。
`.env`ファイルにて、NGINXのポートと、MYSQLのポートを指定できるので、任意のポートに変更できます。

また、Makefileのinstallコマンド中で、`.env.example`をコピーして`.env`ファイルを作成するようにしています。
ですので、まだinstallしていない場合は、上記のファイルコピーについては不要です。