### PR TITLE
#18 ユーザ一覧APIを作成する

### DIFF
--- a/api/app/Http/Controllers/UserController.php
+++ b/api/app/Http/Controllers/UserController.php
@@ -1,7 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\UserResource;
+use App\UseCases\User\ListAction;
 use App\UseCases\User\VerifyAction;
 
 class UserController extends Controller
@@ -17,5 +21,13 @@ class UserController extends Controller
         }
         return response()->json(['message' => '指定されたユーザは存在しません。'], 404);
     }
-}
 
+    /**
+     * ユーザー情報一覧
+     */
+    public function index(ListAction $action)
+    {
+        $list = $action();
+        return UserResource::collection($list->get());
+    }
+}

--- a/api/app/UseCases/User/ListAction.php
+++ b/api/app/UseCases/User/ListAction.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+namespace App\UseCases\User;
+
+use App\Models\User;
+
+/**
+ * ユーザー情報一覧取得アクション
+ */
+class ListAction
+{
+    /**
+     * ユーザー情報一覧を取得する
+     * @return \MatanYadaev\EloquentSpatial\SpatialBuilder ユーザー情報一覧クエリ
+     */
+    public function __invoke()
+    {
+        // とりあえずすべて取得
+        // id順に並べる
+        $list = User::orderBy('id');
+        return $list;
+    }
+}
+

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 use App\Http\Controllers\AdminUserController;
 use App\Http\Controllers\MatterController;
@@ -16,6 +18,9 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+/**
+ * 管理者用
+ */
 // 管理者機能
 Route::prefix('console')->group(function () {
     // ログイン
@@ -28,10 +33,15 @@ Route::prefix('console')->group(function () {
 
         // 管理者情報取得
         Route::get('admin-users/me', [AdminUserController::class, 'me']);
-
     });
+
+    // ユーザ一覧
+    Route::get('users', [UserController::class, 'index']);
 });
 
+/**
+ * 一般ユーザー用
+ */
 // 害獣情報一覧
 Route::get('matters', [MatterController::class, 'index']);
 // 害獣情報作成
@@ -40,5 +50,3 @@ Route::post('matters', [MatterController::class, 'create']);
 // ユーザ確認
 Route::get('users/{userId}/verify', [UserController::class, 'verify'])
     ->whereUuid('user');
-
-

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -36,6 +36,10 @@ Route::prefix('console')->group(function () {
         // 管理者情報取得
         Route::get('admin-users/me', [AdminUserController::class, 'me']);
 
+        // 害獣情報一覧
+        Route::get('matters', [ConsoleMatterController::class, 'index']);
+        // 害獣情報作成
+        Route::post('matters', [ConsoleMatterController::class, 'create']);
     });
 
     // ユーザ一覧

--- a/api/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -80,12 +80,6 @@ class UserControllerTest extends ControllerTestCase
             'description' => 'テストユーザ3の説明',
         ]);
 
-        // $action = new ListAction();
-
-        // テスト実行
-        /** @var User[] */
-        // $results = $action()->get();
-
         // アクションの戻り値をモックする
         /** @var SpatialBuilder|MockInterface */
         $builder = Mockery::mock(SpatialBuilder::class);
@@ -93,7 +87,6 @@ class UserControllerTest extends ControllerTestCase
             ->andReturn([$user1, $user2, $user3]);
 
         $this->mockAction(ListAction::class, $builder);
-
 
         $response = $this->getJson("api/console/users");
 

--- a/api/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -1,8 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\User;
+use App\UseCases\User\ListAction;
 use Tests\ControllerTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Ramsey\Uuid\Uuid;
@@ -32,7 +35,7 @@ class UserControllerTest extends ControllerTestCase
         // ステータスコードの検証
         // JSONの検証
         $response->assertStatus(200) // 200 OK
-                 ->assertJson(['message' => 'OK']);
+                ->assertJson(['message' => 'OK']);
     }
 
     /**
@@ -52,9 +55,42 @@ class UserControllerTest extends ControllerTestCase
         // ステータスコードの検証
         // JSONの検証
         $response->assertStatus(404) // 404 NotFound
-                 ->assertJson(['message' => '指定されたユーザは存在しません。']);
+                ->assertJson(['message' => '指定されたユーザは存在しません。']);
     }
 
+    /**
+     * 登録ユーザーの一覧が取得できること
+     */
+    public function testIndex()
+    {
+        // テスト準備
+        // ユーザを作成する
+        /** @var User */
+        $user1 = User::factory()->create([
+            'name' => 'テストユーザ1',
+            'description' => 'テストユーザ1の説明',
+        ]);
+        $user2 = User::factory()->create([
+            'name' => 'テストユーザ2',
+            'description' => 'テストユーザ2の説明',
+        ]);
+        $user3 = User::factory()->create([
+            'name' => 'テストユーザ3',
+            'description' => 'テストユーザ3の説明',
+        ]);
+
+        $user_list = [$user1, $user2, $user3];
+
+        /** @var User[] */
+        $results = $action()->get();
+
+        $response = $this->getJson("api/console/users");
+
+        // テスト確認
+        // ステータスコードの検証
+        // JSONの検証
+        // 200 OK
+        $response->assertStatus(200)->assertSame(3, count($results));
+                // ->assertJson(['message' => 'OK']);
+    }
 }
-
-

--- a/api/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\UseCases\User\ListAction;
 use Tests\ControllerTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
 use Ramsey\Uuid\Uuid;
 
 class UserControllerTest extends ControllerTestCase
@@ -79,18 +80,27 @@ class UserControllerTest extends ControllerTestCase
             'description' => 'テストユーザ3の説明',
         ]);
 
-        $user_list = [$user1, $user2, $user3];
+        // $action = new ListAction();
 
+        // テスト実行
         /** @var User[] */
-        $results = $action()->get();
+        // $results = $action()->get();
+
+        // アクションの戻り値をモックする
+        /** @var SpatialBuilder|MockInterface */
+        $builder = Mockery::mock(SpatialBuilder::class);
+        $builder->shouldReceive('get')
+            ->andReturn([$user1, $user2, $user3]);
+
+        $this->mockAction(ListAction::class, $builder);
+
 
         $response = $this->getJson("api/console/users");
 
         // テスト確認
         // ステータスコードの検証
         // JSONの検証
-        // 200 OK
-        $response->assertStatus(200)->assertSame(3, count($results));
-                // ->assertJson(['message' => 'OK']);
+        $response->assertStatus(200) // 200 OK
+            ->assertJsonCount(3); // 3件ある
     }
 }

--- a/api/tests/Unit/UseCases/User/ListActionTest.php
+++ b/api/tests/Unit/UseCases/User/ListActionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\UseCases\User;
+
+use App\Models\User;
+use App\UseCases\User\ListAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use MatanYadaev\EloquentSpatial\Objects\Point;
+use Tests\TestCase;
+
+use function count;
+
+class ListActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * ユーザー情報一覧を取得できること
+     * idの昇順になっていること
+     */
+    public function testList01()
+    {
+        // テスト準備
+        // ユーザを作成する
+        /** @var User */
+        $user1 = User::factory()->create([
+            'name' => 'テストユーザ1',
+            'description' => 'テストユーザ1の説明',
+        ]);
+        $user2 = User::factory()->create([
+            'name' => 'テストユーザ2',
+            'description' => 'テストユーザ2の説明',
+        ]);
+        $user3 = User::factory()->create([
+            'name' => 'テストユーザ3',
+            'description' => 'テストユーザ3の説明',
+        ]);
+
+        $action = new ListAction();
+
+        // テスト実行
+        /** @var User[] */
+        $results = $action()->get();
+
+        // テスト確認
+        $this->assertSame(3, count($results));
+        $this->assertSame($user1->id, $results[0]->id);
+        $this->assertSame($user2->id, $results[1]->id);
+        $this->assertSame($user3->id, $results[2]->id);
+    }
+}


### PR DESCRIPTION
matters（獣害情報）一覧を参考にユーザー一覧（get：/console/の下にあるので、おそらく管理者用？）を作成してみました。

一般ユーザーには他のユーザー一覧が見える必要はなさそうかなあと思うので、とりあえずは管理者にだけユーザー一覧が取得できればいいのではと思っています。

テストは全て通過しています。（おそらく問題ないとおもいますが、、、）

レビューをお願いいたします！