### PR TITLE
closed #19 管理者用ユーザ作成APIを作成した

### DIFF
--- a/api/app/Http/Controllers/Console/UserController.php
+++ b/api/app/Http/Controllers/Console/UserController.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers\Console;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\User\SaveRequest;
+use App\Http\Resources\UserResource;
+use App\UseCases\User\SaveAction;
+
+/**
+ * 管理者用コンソールユーザコントローラ
+ */
+class UserController extends Controller
+{
+    /**
+     * ユーザ情報作成
+     */
+    public function create(SaveRequest $req, SaveAction $action)
+    {
+        $entity = $req->makeEntity();
+        $user = $action($entity, null);
+        return response()->json(new UserResource($user), 201);
+    }
+}
+

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Console\AdminUserController;
 use App\Http\Controllers\MatterController;
 // ユーザ用のMatterControllerで名前がかぶるので、as で別名を付けています。
 use App\Http\Controllers\Console\MatterController as ConsoleMatterController;
+use App\Http\Controllers\Console\UserController as ConsoleUserController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -40,6 +41,9 @@ Route::prefix('console')->group(function () {
         Route::get('matters', [ConsoleMatterController::class, 'index']);
         // 害獣情報作成
         Route::post('matters', [ConsoleMatterController::class, 'create']);
+
+        // ユーザ情報作成
+        Route::post('users', [ConsoleUserController::class, 'create']);
     });
 
     // ユーザ一覧

--- a/api/tests/Feature/Http/Controllers/Console/UserControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/Console/UserControllerTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Http\Controllers\Console;
+
+use App\Models\AdminUser;
+use App\Models\User;
+use App\UseCases\User\SaveAction;
+use Tests\ControllerTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * 管理者コンソールのユーザコントローラテスト
+ */
+class UserControllerTest extends ControllerTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * ユーザ情報を作成できること
+     */
+    public function testCreate()
+    {
+        /** @var AdminUser */
+        $admin = AdminUser::factory()->create();
+
+        // テスト準備
+        $user = User::factory()->create();
+        $this->mockAction(SaveAction::class, $user);
+
+        $data = [
+            'name' => 'テスト太郎',
+            'description' => "テスト説明j",
+        ];
+
+        // テスト実行
+        // リクエストを送信する
+        $response = $this->actingAs($admin, 'admin')
+            ->postJson("api/console/users", $data);
+
+        // テスト確認
+        // ステータスコードの検証
+        $response->assertStatus(201); // 201 Cerated
+    }
+}
+
+


### PR DESCRIPTION
# 概要
管理者用ユーザ作成APIを作成しました。
管理者権限でユーザを作成できます。

URIは以下のとおりです。
`POST: /api/console/users`
