### PR TITLE
closed #43 ユーザ一覧画面とユーザリストAPIをつなぎごんだ

### DIFF
--- a/api/app/Http/Controllers/Console/MatterController.php
+++ b/api/app/Http/Controllers/Console/MatterController.php
@@ -21,7 +21,7 @@ class MatterController extends Controller
     public function index(ListAction $action)
     {
         $list = $action();
-        return MatterResource::collection($list->get());
+        return MatterResource::collection($list->paginate(20));
     }
 
     /**

--- a/api/app/Http/Controllers/Console/UserController.php
+++ b/api/app/Http/Controllers/Console/UserController.php
@@ -19,7 +19,7 @@ class UserController extends Controller
     public function index(ListAction $action)
     {
         $list = $action();
-        return UserResource::collection($list->get());
+        return UserResource::collection($list->paginate(20));
     }
 
     /**

--- a/api/app/Http/Controllers/Console/UserController.php
+++ b/api/app/Http/Controllers/Console/UserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Console;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\User\SaveRequest;
 use App\Http\Resources\UserResource;
+use App\UseCases\User\ListAction;
 use App\UseCases\User\SaveAction;
 
 /**
@@ -12,6 +13,15 @@ use App\UseCases\User\SaveAction;
  */
 class UserController extends Controller
 {
+    /**
+     * ユーザ情報一覧
+     */
+    public function index(ListAction $action)
+    {
+        $list = $action();
+        return UserResource::collection($list->get());
+    }
+
     /**
      * ユーザ情報作成
      */

--- a/api/app/Http/Controllers/UserController.php
+++ b/api/app/Http/Controllers/UserController.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Http\Resources\UserResource;
-use App\UseCases\User\ListAction;
 use App\UseCases\User\VerifyAction;
 
 class UserController extends Controller
@@ -20,14 +18,5 @@ class UserController extends Controller
             return response()->json(['message' => 'OK'], 200);
         }
         return response()->json(['message' => '指定されたユーザは存在しません。'], 404);
-    }
-
-    /**
-     * ユーザー情報一覧
-     */
-    public function index(ListAction $action)
-    {
-        $list = $action();
-        return UserResource::collection($list->get());
     }
 }

--- a/api/app/UseCases/User/ListAction.php
+++ b/api/app/UseCases/User/ListAction.php
@@ -2,7 +2,7 @@
 namespace App\UseCases\User;
 
 use App\Models\User;
-use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * ユーザー情報一覧取得アクション

--- a/api/app/UseCases/User/ListAction.php
+++ b/api/app/UseCases/User/ListAction.php
@@ -2,6 +2,7 @@
 namespace App\UseCases\User;
 
 use App\Models\User;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 /**
  * ユーザー情報一覧取得アクション
@@ -10,9 +11,9 @@ class ListAction
 {
     /**
      * ユーザー情報一覧を取得する
-     * @return \MatanYadaev\EloquentSpatial\SpatialBuilder ユーザー情報一覧クエリ
+     * @return Builder<User> ユーザー情報一覧クエリ
      */
-    public function __invoke()
+    public function __invoke(): Builder
     {
         // とりあえずすべて取得
         // id順に並べる

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -42,12 +42,11 @@ Route::prefix('console')->group(function () {
         // 害獣情報作成
         Route::post('matters', [ConsoleMatterController::class, 'create']);
 
+        // ユーザ情報一覧
+        Route::get('users', [ConsoleUserController::class, 'index']);
         // ユーザ情報作成
         Route::post('users', [ConsoleUserController::class, 'create']);
     });
-
-    // ユーザ一覧
-    Route::get('users', [UserController::class, 'index']);
 });
 
 /**

--- a/api/tests/Feature/Http/Controllers/Console/MatterControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/Console/MatterControllerTest.php
@@ -10,6 +10,7 @@ use App\UseCases\Matter\ListAction;
 use App\UseCases\Matter\SaveAction;
 use Tests\ControllerTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
 use MatanYadaev\EloquentSpatial\SpatialBuilder;
 
 /**
@@ -33,11 +34,16 @@ class MatterControllerTest extends ControllerTestCase
         $matter2 = Matter::factory()->create();
         $matter3 = Matter::factory()->create();
 
+        // ペジネータ作成
+        // LengthAwarePaginatorで、ペジネータを手動生成できます。
+        $paginator = new LengthAwarePaginator([$matter1, $matter2, $matter3], 2, 20);
+
         // アクションの戻り値をモックする
         /** @var SpatialBuilder|MockInterface */
         $builder = Mockery::mock(SpatialBuilder::class);
-        $builder->shouldReceive('get')
-            ->andReturn([$matter1, $matter2, $matter3]);
+        $builder->shouldReceive('paginate')
+            ->withArgs([20])
+            ->andReturn($paginator);
 
         $this->mockAction(ListAction::class, $builder);
 

--- a/api/tests/Feature/Http/Controllers/Console/UserControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/Console/UserControllerTest.php
@@ -6,9 +6,10 @@ use App\Models\AdminUser;
 use App\Models\User;
 use App\UseCases\User\ListAction;
 use App\UseCases\User\SaveAction;
-use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder;
 use Tests\ControllerTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Mockery;
 
 /**
@@ -69,11 +70,16 @@ class UserControllerTest extends ControllerTestCase
             'description' => 'テストユーザ3の説明',
         ]);
 
+        // ペジネータ作成
+        // LengthAwarePaginatorで、ペジネータを手動生成できます。
+        $paginator = new LengthAwarePaginator([$user1, $user2, $user3], 2, 20);
+
         // アクションの戻り値をモックする
-        /** @var SpatialBuilder|MockInterface */
+        /** @var Builder|MockInterface */
         $builder = Mockery::mock(Builder::class);
-        $builder->shouldReceive('get')
-            ->andReturn([$user1, $user2, $user3]);
+        $builder->shouldReceive('paginate')
+            ->withArgs([20])
+            ->andReturn($paginator);
 
         $this->mockAction(ListAction::class, $builder);
 

--- a/api/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\User;
-use App\UseCases\User\ListAction;
 use Tests\ControllerTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Mockery;
 use Ramsey\Uuid\Uuid;
 
 class UserControllerTest extends ControllerTestCase
@@ -59,41 +57,4 @@ class UserControllerTest extends ControllerTestCase
                 ->assertJson(['message' => '指定されたユーザは存在しません。']);
     }
 
-    /**
-     * 登録ユーザーの一覧が取得できること
-     */
-    public function testIndex()
-    {
-        // テスト準備
-        // ユーザを作成する
-        /** @var User */
-        $user1 = User::factory()->create([
-            'name' => 'テストユーザ1',
-            'description' => 'テストユーザ1の説明',
-        ]);
-        $user2 = User::factory()->create([
-            'name' => 'テストユーザ2',
-            'description' => 'テストユーザ2の説明',
-        ]);
-        $user3 = User::factory()->create([
-            'name' => 'テストユーザ3',
-            'description' => 'テストユーザ3の説明',
-        ]);
-
-        // アクションの戻り値をモックする
-        /** @var SpatialBuilder|MockInterface */
-        $builder = Mockery::mock(SpatialBuilder::class);
-        $builder->shouldReceive('get')
-            ->andReturn([$user1, $user2, $user3]);
-
-        $this->mockAction(ListAction::class, $builder);
-
-        $response = $this->getJson("api/console/users");
-
-        // テスト確認
-        // ステータスコードの検証
-        // JSONの検証
-        $response->assertStatus(200) // 200 OK
-            ->assertJsonCount(3); // 3件ある
-    }
 }

--- a/web/components/users/UserTable.tsx
+++ b/web/components/users/UserTable.tsx
@@ -1,6 +1,6 @@
 import { ColumnDef } from '@tanstack/react-table'
 import PaginationTable from 'components/atoms/PaginationTable'
-import { Pagination } from 'models/Pagination'
+import useGetUserPage from 'hooks/console/user/useGetUserPage'
 import { User } from 'models/User'
 import React, { useMemo } from 'react'
 import { Button } from 'react-bootstrap'
@@ -8,6 +8,8 @@ import { Button } from 'react-bootstrap'
 type Props = {}
 
 const UserTable = (props: Props) => {
+  const { data } = useGetUserPage()
+
   const columns: ColumnDef<User>[] = useMemo(() => {
     const columns: ColumnDef<User>[] = [
       {
@@ -39,39 +41,7 @@ const UserTable = (props: Props) => {
     return columns
   }, [])
 
-  //仮データ
-  const pagination: Pagination<User> = {
-    data: [
-      {
-        id: 'e6903c19-0b3e-4157-8a64-497762cb5b1b',
-        name: 'テスト太郎',
-        createdAt: '2023-04-01',
-        updatedAt: '2023-04-01',
-      },
-      {
-        id: 'c9d5f476-455c-45b8-97eb-f8bc4063f30a',
-        name: 'テスト次郎',
-        createdAt: '2023-03-01',
-        updatedAt: '2023-03-01',
-      },
-    ],
-    meta: {
-      currentPage: 1,
-      from: 1,
-      lastPage: 1,
-      path: '',
-      perPage: 20,
-      to: 2,
-      total: 2,
-    },
-  }
-
-  return (
-    <PaginationTable
-      columns={columns}
-      pagination={pagination}
-    ></PaginationTable>
-  )
+  return <PaginationTable columns={columns} pagination={data}></PaginationTable>
 }
 
 export default UserTable

--- a/web/hooks/console/user/useGetUserPage.ts
+++ b/web/hooks/console/user/useGetUserPage.ts
@@ -1,0 +1,15 @@
+import { Pagination } from 'models/Pagination'
+import { User } from 'models/User'
+import useSWR from 'swr'
+
+/**
+ * ページングされたユーザ情報を取得する
+ */
+const useGetUserPage = () => {
+  const { data } = useSWR<Pagination<User>>('/api/console/users')
+  return {
+    data,
+  }
+}
+
+export default useGetUserPage


### PR DESCRIPTION
# 概要
ユーザ一覧画面とユーザリストAPIをつなぎごんだ

管理者コンソールのユーザ一覧画面について、バックエンドのユーザリストAPIを利用して、表示できるようにした。
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/20750714/233676047-7695826e-255f-488c-bd13-197eaaf3fa42.png">
