### PR TITLE
close #41 ユーザの新規作成機能を作成した

### DIFF
--- a/api/app/Http/Requests/User/SaveRequest.php
+++ b/api/app/Http/Requests/User/SaveRequest.php
@@ -19,7 +19,7 @@ class SaveRequest extends FormRequest
     {
         return [
             'name' => 'required|max:255',
-            'description' => 'required|max:10000', // DB的にはTEXT型なので文字制限は無いが、とりあえず上限を10000字とする
+            'description' => 'present|max:10000', // DB的にはTEXT型なので文字制限は無いが、とりあえず上限を10000字とする
         ];
     }
 

--- a/api/tests/Feature/Http/Requests/User/SaveRequestTest.php
+++ b/api/tests/Feature/Http/Requests/User/SaveRequestTest.php
@@ -85,7 +85,7 @@ class SaveRequestTest extends FormRequestTestCase
         unset($this->data['description']);
         $actual = $this->getValidateErrors($this->data, SaveRequest::class);
         $this->assertSame(1, count($actual));
-        $this->assertSame('概要は必ず指定してください。', Arr::get($actual, 'description.0'));
+        $this->assertSame('概要が存在していません。', Arr::get($actual, 'description.0'));
     }
 
     /**
@@ -105,6 +105,18 @@ class SaveRequestTest extends FormRequestTestCase
         $actual = $this->getValidateErrors($data, SaveRequest::class);
         $this->assertSame(1, count($actual));
         $this->assertSame('概要は、10000文字以下で指定してください。', Arr::get($actual, 'description.0'));
+    }
+
+    /**
+     * 概要は空でも良いこと
+     */
+    public function testDescription03()
+    {
+        $data = array_merge($this->data, [
+            'description' => "", 
+        ]);
+        $actual = $this->getValidateErrors($this->data, SaveRequest::class);
+        $this->assertSame(0, count($actual));
     }
 }
 

--- a/web/components/atoms/CustomTable.tsx
+++ b/web/components/atoms/CustomTable.tsx
@@ -3,6 +3,7 @@ import { get, useController, useFormContext } from 'react-hook-form'
 
 type Props = {
   name: string
+  label?: string
 } & FormControlProps
 
 /**
@@ -20,11 +21,17 @@ const InputForm = (props: Props) => {
   })
   return (
     <>
+      {props.label !== undefined && <Form.Label>{props.label}</Form.Label>}
       <Form.Control
         {...field}
         {...formControlProps}
         isInvalid={!!get(errors, name)}
       />
+      {errors.name && (
+        <Form.Control.Feedback type='invalid'>
+          {errors.name.message?.toString()}
+        </Form.Control.Feedback>
+      )}
     </>
   )
 }

--- a/web/components/users/UserForm.tsx
+++ b/web/components/users/UserForm.tsx
@@ -1,0 +1,27 @@
+import InputForm from 'components/atoms/CustomTable'
+import React from 'react'
+import { Form } from 'react-bootstrap'
+
+const UserForm = () => {
+  return (
+    <>
+      <Form.Group className='py-2'>
+        <InputForm
+          name='name'
+          label='ユーザー名'
+          placeholder='ユーザー名'
+        ></InputForm>
+      </Form.Group>
+      <Form.Group className='py-2'>
+        <InputForm
+          as='textarea'
+          name='description'
+          label='メモ'
+          placeholder='メモ'
+        ></InputForm>
+      </Form.Group>
+    </>
+  )
+}
+
+export default UserForm

--- a/web/hooks/console/user/useAddUser.ts
+++ b/web/hooks/console/user/useAddUser.ts
@@ -1,0 +1,40 @@
+import useAxios from 'axios-hooks'
+import { User } from 'models/User'
+import * as yup from 'yup'
+
+export type AddUserForm = {
+  name: string
+  description: string
+}
+
+export const userSchema = yup.object<AddUserForm>().shape({
+  name: yup.string().max(255).required(),
+  description: yup.string().max(2000),
+})
+
+/**
+ * ユーザ新規作成フック
+ */
+const useAddUser = () => {
+  const [{ loading, error }, exec] = useAxios<User>({
+    url: `/api/users`,
+    method: 'POST',
+  })
+
+  const execute = (form: AddUserForm) => {
+    exec({
+      data: {
+        name: form.name,
+        description: form.description,
+      },
+    })
+  }
+
+  return {
+    execute,
+    loading,
+    error,
+  }
+}
+
+export default useAddUser

--- a/web/hooks/console/user/useAddUser.ts
+++ b/web/hooks/console/user/useAddUser.ts
@@ -17,12 +17,12 @@ export const userSchema = yup.object<AddUserForm>().shape({
  */
 const useAddUser = () => {
   const [{ loading, error }, exec] = useAxios<User>({
-    url: `/api/users`,
+    url: `/api/console/users`,
     method: 'POST',
   })
 
   const execute = (form: AddUserForm) => {
-    exec({
+    return exec({
       data: {
         name: form.name,
         description: form.description,

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "jsxSingleQuote": true
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.1.0",
     "@tanstack/react-table": "^8.7.6",
     "axios": "^1.3.2",
     "axios-hooks": "^4.0.0",
@@ -30,7 +31,9 @@
     "react-geolocated": "^4.0.3",
     "react-hook-form": "^7.43.2",
     "react-icons": "^4.8.0",
-    "swr": "^2.0.4"
+    "swr": "^2.0.4",
+    "yup": "^1.1.1",
+    "yup-locale-ja": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "18.11.7",

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,11 +1,11 @@
+import 'bootstrap/dist/css/bootstrap.min.css'
 import '../styles/globals.css'
+import styles from '../styles/Home.module.css'
 import { configure } from 'axios-hooks'
 import type { AppProps } from 'next/app'
 import axios from 'libs/axios'
 import { SWRConfig } from 'swr'
-import styles from '../styles/Home.module.css'
 import Head from 'next/head'
-import 'bootstrap/dist/css/bootstrap.min.css'
 import { FunctionComponent, ReactElement, ReactNode } from 'react'
 import { NextPage } from 'next'
 

--- a/web/pages/console/matters/index.tsx
+++ b/web/pages/console/matters/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { NextPageWithLayout } from '_app'
 import Layout from 'components/layouts/ConsoleLayout'
 import MatterTable from 'components/matters/MatterTable'
-import { Col, Row } from 'react-bootstrap'
+import { Card, Col, Row } from 'react-bootstrap'
 
 const ConsoleMatterList: NextPageWithLayout = () => {
   return (
@@ -14,7 +14,9 @@ const ConsoleMatterList: NextPageWithLayout = () => {
       </Row>
       <Row>
         <Col>
-          <MatterTable />
+          <Card className='py-3 px-4'>
+            <MatterTable />
+          </Card>
         </Col>
       </Row>
     </>

--- a/web/pages/console/users/index.tsx
+++ b/web/pages/console/users/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { NextPageWithLayout } from '_app'
 import Layout from 'components/layouts/ConsoleLayout'
-import { Col, Row } from 'react-bootstrap'
+import { Button, Card, Col, Row } from 'react-bootstrap'
 import UserTable from 'components/users/UserTable'
+import Link from 'next/link'
 
 const ConsoleUserList: NextPageWithLayout = () => {
   return (
@@ -14,7 +15,14 @@ const ConsoleUserList: NextPageWithLayout = () => {
       </Row>
       <Row>
         <Col>
-          <UserTable />
+          <Card className='py-3 px-4'>
+            <Link href='/console/users/new'>
+              <div className='float-end mb-2'>
+                <Button variant='primary'>ユーザ新規作成</Button>
+              </div>
+            </Link>
+            <UserTable />
+          </Card>
         </Col>
       </Row>
     </>

--- a/web/pages/console/users/new.tsx
+++ b/web/pages/console/users/new.tsx
@@ -9,8 +9,11 @@ import useAddUser, {
 } from 'hooks/console/user/useAddUser'
 import UserForm from 'components/users/UserForm'
 import { yupResolver } from '@hookform/resolvers/yup'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
 
 const ConsoleUserNew: NextPageWithLayout = () => {
+  const router = useRouter()
   const form = useForm<AddUserForm>({
     mode: 'onSubmit',
     resolver: yupResolver(userSchema),
@@ -23,8 +26,11 @@ const ConsoleUserNew: NextPageWithLayout = () => {
   const { execute, loading } = useAddUser()
 
   const onSubmit = () => {
-    console.log(getValues())
-    // execute(getValues())
+    execute(getValues()).then(() => {
+      // 作成に成功
+      // 一覧ページにリダイレクトする
+      router.push('/console/users')
+    })
   }
 
   return (
@@ -41,14 +47,21 @@ const ConsoleUserNew: NextPageWithLayout = () => {
               <FormProvider {...form}>
                 <UserForm />
               </FormProvider>
-              <Button
-                className='float-end mt-2'
-                variant='primary'
-                onClick={onSubmit}
-                disabled={loading}
-              >
-                新規作成
-              </Button>
+              <div className='float-end mt-2'>
+                <Link href='/console/users'>
+                  <Button variant='secondary' className='ms-1'>
+                    一覧に戻る
+                  </Button>
+                </Link>
+                <Button
+                  variant='primary'
+                  className='ms-1'
+                  onClick={handleSubmit(onSubmit)}
+                  disabled={loading}
+                >
+                  新規作成
+                </Button>
+              </div>
             </Form>
           </Card>
         </Col>

--- a/web/pages/console/users/new.tsx
+++ b/web/pages/console/users/new.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { NextPageWithLayout } from '_app'
+import Layout from 'components/layouts/ConsoleLayout'
+import { Button, Card, Col, Form, Row } from 'react-bootstrap'
+import { FormProvider, useForm } from 'react-hook-form'
+import useAddUser, {
+  AddUserForm,
+  userSchema,
+} from 'hooks/console/user/useAddUser'
+import UserForm from 'components/users/UserForm'
+import { yupResolver } from '@hookform/resolvers/yup'
+
+const ConsoleUserNew: NextPageWithLayout = () => {
+  const form = useForm<AddUserForm>({
+    mode: 'onSubmit',
+    resolver: yupResolver(userSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+    },
+  })
+  const { handleSubmit, getValues } = form
+  const { execute, loading } = useAddUser()
+
+  const onSubmit = () => {
+    console.log(getValues())
+    // execute(getValues())
+  }
+
+  return (
+    <>
+      <Row>
+        <Col>
+          <h3>ユーザー情報新規作成</h3>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Card className='py-3 px-4'>
+            <Form onSubmit={handleSubmit(onSubmit)}>
+              <FormProvider {...form}>
+                <UserForm />
+              </FormProvider>
+              <Button
+                className='float-end mt-2'
+                variant='primary'
+                onClick={onSubmit}
+                disabled={loading}
+              >
+                新規作成
+              </Button>
+            </Form>
+          </Card>
+        </Col>
+      </Row>
+    </>
+  )
+}
+
+ConsoleUserNew.getLayout = function getLayout(page) {
+  return <Layout>{page}</Layout>
+}
+
+export default ConsoleUserNew

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -4,6 +4,7 @@ body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  background-color: rgb(240, 244, 247);
 }
 
 a {
@@ -24,4 +25,9 @@ a {
   line-height: 12.5px;
   padding: 2px;
   z-index: 800;
+}
+
+.card {
+  border: 0px;
+  box-shadow: rgba(50, 50, 93, 0.02) 0 2px 5px -1px, rgba(0, 0, 0, 0.05) 0 1px 3px -1px;
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -180,6 +180,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@hookform/resolvers@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.1.0.tgz#ff83ef4aa6078173201da131ceea4c3583b67034"
+  integrity sha512-z0A8K+Nxq+f83Whm/ajlwE6VtQlp/yPHZnXw7XWVPIGm1Vx0QV8KThU3BpbBRfAZ7/dYqCKKBNnQh85BkmBKkA==
+
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz#38aec044c6c828f6ed51d5d7ae3d9b9faf6dbb0f"
@@ -2499,6 +2504,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 protocol-buffers-schema@^3.3.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz#77bc75a48b2ff142c1ad5b5b90c94cd0fa2efd03"
@@ -2861,12 +2871,22 @@ texture-compressor@^1.0.2:
     argparse "^1.0.10"
     image-size "^0.7.4"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"
@@ -2911,6 +2931,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typescript@4.8.4:
   version "4.8.4"
@@ -3011,3 +3036,18 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup-locale-ja@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yup-locale-ja/-/yup-locale-ja-1.0.0.tgz#a6fd25a0c341f24818b2c312bd7ca4780348aba9"
+  integrity sha512-HTlHQUIC1KzvZw3xYfeDEpS68hSEE3PcvJXJwmQ1uPAJkTyAAZ+9LgQwwS8yTr4IfuDa3niuOUhExihewNcl1g==
+
+yup@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.1.1.tgz#49dbcf5ae7693ed0a36ed08a9e9de0a09ac18e6b"
+  integrity sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"


### PR DESCRIPTION
# 概要
ユーザの新規作成画面を作成しました。

ユーザの新規作成画面は、管理者コンソール画面のユーザ一覧の「ユーザ新規作成」ボタンから移動可能です。
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/20750714/233767098-55207df2-fbf5-4635-9404-48296acfa9bf.png">

ユーザ新規作成が可能です。
バリデーションは機能していますが、エラー内容が英語のままです。
これは今後のIssueで直していきましょう。
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/20750714/233767140-4987b4d8-cba2-4b69-863e-a7218558c8e4.png">
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/20750714/233767182-a952f1d2-a6f7-494e-9c95-2737c125d984.png">


