### PR TITLE
closed #62 獣害情報一覧 検索コンポーネントを作成した

### DIFF
--- a/api/app/Http/Controllers/Console/MatterController.php
+++ b/api/app/Http/Controllers/Console/MatterController.php
@@ -5,6 +5,7 @@
 namespace App\Http\Controllers\Console;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Matter\SearchRequest;
 use App\Http\Requests\Matter\UpdateRequest;
 use App\Http\Resources\MatterResource;
 use App\Models\Matter;
@@ -20,9 +21,9 @@ class MatterController extends Controller
     /**
      * 害獣情報一覧
      */
-    public function index(ListAction $action)
+    public function index(SearchRequest $req, ListAction $action)
     {
-        $list = $action();
+        $list = $action($req->makeEntity());
         $list->with(['user']);
         return MatterResource::collection($list->paginate(20));
     }

--- a/api/app/Http/Requests/Matter/SearchRequest.php
+++ b/api/app/Http/Requests/Matter/SearchRequest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests\Matter;
+
+use App\UseCases\Matter\ListEntity;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Carbon;
+
+class SearchRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'q' => 'string|max:255',
+            'from' => 'nullable|date_format:Y-m-d',
+            'to' => 'nullable|date_format:Y-m-d',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'q' => '検索文字',
+            'from' => '日付(自)',
+            'to' => '日付(至)',
+        ];
+    }
+
+    /**
+     * 獣害情報検索データの生成
+     */
+    public function makeEntity(): ListEntity
+    {
+        return new ListEntity([
+            'query' =>  $this->input('q'),
+            'from' =>  $this->input('from') ? new Carbon($this->input('from')) : null,
+            'to' =>  $this->input('to') ? new Carbon($this->input('to')) : null,
+        ]);
+    }
+}
+
+

--- a/api/app/UseCases/Matter/ListAction.php
+++ b/api/app/UseCases/Matter/ListAction.php
@@ -13,15 +13,23 @@ class ListAction
 {
     /**
      * 害獣情報一覧を取得する
-     * @param $entity 検索情報
+     * @param $entity ListEntity|null 検索情報
      * @return\MatanYadaev\EloquentSpatial\SpatialBuilder<Matter> 害獣情報一覧クエリ
      */
-    public function __invoke(ListEntity $entity): Builder
+    public function __invoke(ListEntity $entity = null): Builder
     {
-        $query =  Matter::query();
-        $query->leftJoin('users', function ($join) {
-            $join->on('matters.user_id', '=', 'users.id');
-        });
+        if ($entity === null) {
+            $entity = new ListEntity([
+                'query' => '',
+                'from' => null,
+                'to' => null,
+            ]);
+        }
+
+        $query = Matter::select('matters.*')
+            ->leftJoin('users', function ($join) {
+                $join->on('matters.user_id', '=', 'users.id');
+            });
 
         $words = StringUtil::explodeWhitespace($entity->getQuery());
         foreach ($words as $word) {

--- a/api/app/UseCases/Matter/ListAction.php
+++ b/api/app/UseCases/Matter/ListAction.php
@@ -3,6 +3,7 @@
 namespace App\UseCases\Matter;
 
 use App\Models\Matter;
+use App\Utils\StringUtil;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -12,14 +13,33 @@ class ListAction
 {
     /**
      * 害獣情報一覧を取得する
-     * @return \MatanYadaev\EloquentSpatial\SpatialBuilder 害獣情報一覧クエリ
-     * @return Builder<Matter>
+     * @param $entity 検索情報
+     * @return\MatanYadaev\EloquentSpatial\SpatialBuilder<Matter> 害獣情報一覧クエリ
      */
-    public function __invoke(): Builder
+    public function __invoke(ListEntity $entity): Builder
     {
-        // とりあえずすべて取得
-        // TODO: 違和感のない程度で絞り込みなどをして、データ数が大きすぎないようにする必要がある
-        $list = Matter::orderBy('applied_at', 'asc');
-        return $list;
+        $query =  Matter::query();
+        $query->leftJoin('users', function ($join) {
+            $join->on('matters.user_id', '=', 'users.id');
+        });
+
+        $words = StringUtil::explodeWhitespace($entity->getQuery());
+        foreach ($words as $word) {
+            $query->where(function ($q) use ($word) {
+                $faz = '%'.addcslashes($word, '%_\\').'%';
+                $q->where('users.id', '=', $word)
+                    ->orwhere('users.name', 'LIKE', $faz);
+            });
+        }
+
+        if ($entity->getFrom() !== null) {
+            $query->whereDate('matters.applied_at', '>=', $entity->getFrom()->format('Y-m-d').' 0:00:00');
+        }
+        if ($entity->getTo() !== null) {
+            $query->whereDate('matters.applied_at', '<=', $entity->getTo()->format('Y-m-d').' 23:59:59');
+        }
+
+        $query->orderBy('applied_at', 'desc');
+        return $query;
     }
 }

--- a/api/app/UseCases/Matter/ListEntity.php
+++ b/api/app/UseCases/Matter/ListEntity.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\UseCases\Matter;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+
+/**
+ * 獣害情報一覧データ
+ */
+class ListEntity
+{
+    /** @var string 検索文字 */
+    private $query;
+    /** @var Carbon|null 日付(自) */
+    private $from;
+    /** @var Carbon|null 日付(至) */
+    private $to;
+
+    public function __construct(array $data)
+    {
+        $this->query = Arr::get($data, 'query');
+        $this->from = Arr::get($data, 'from');
+        $this->to = Arr::get($data, 'to');
+    }
+
+    /**
+     * 検索文字
+     * @return string
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * 日付(自)
+     * @return Carbon|null
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * 日付(至)
+     * @return Carbon|null
+     */
+    public function getTo()
+    {
+        return $this->to;
+    }
+}
+
+

--- a/api/app/Utils/StringUtil.php
+++ b/api/app/Utils/StringUtil.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace App\Utils;
+
+use Illuminate\Support\Collection;
+use function strlen;
+use function in_array;
+
+/**
+ * 文字列関連の汎用関数群
+ */
+class StringUtil
+{
+
+    /**
+     * 文字列が、指定された接頭辞で始まるかどうかを判定する
+     *
+     * @param string $haystack 対象文字列
+     * @param string $needle 接頭辞
+     * @return bool 始まっている/始まっていない
+     */
+    public static function startsWith(string $haystack, string $needle): bool
+    {
+        $length = strlen($needle);
+        return (substr($haystack, 0, $length) === $needle);
+    }
+
+    /**
+     * 文字列が、指定された接尾辞で終わるかどうかを判定する
+     *
+     * @param string $haystack 対象文字列
+     * @param string $needle 接尾辞
+     * @return bool 終わっている/終わっていない
+     */
+    public static function endsWith(string $haystack, string $needle): bool
+    {
+        $length = strlen($needle);
+        if ($length === 0) {
+            return true;
+        }
+        return (substr($haystack, -$length) === $needle);
+    }
+
+    /**
+     * 文字列を半角・全角スペースで区切り、コレクションで返却する
+     * また、重複した文字列がある場合は1つにまとめる
+     * @param string $text 文字列
+     * @return Collection<string> 区切られた文字列コレクション
+     */
+    public static function explodeWhitespace(string $text): Collection
+    {
+        $words = mb_convert_kana($text, 's');
+        $words = preg_split('/[\s]+/', $words, -1, PREG_SPLIT_NO_EMPTY);
+        $unique = [];
+        foreach ($words as $w) {
+            if (!in_array($w, $unique, true)) {
+                $unique[] = $w;
+            }
+        }
+        return collect($unique);
+    }
+}
+

--- a/api/tests/Feature/Http/Requests/Matter/SearchRequestTest.php
+++ b/api/tests/Feature/Http/Requests/Matter/SearchRequestTest.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Http\Requests\Matter;
+
+use App\Http\Requests\Matter\SearchRequest;
+use Tests\FormRequestTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+use function count;
+
+
+class SearchRequestTest extends FormRequestTestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->data = [
+            'q' => "テスト",
+            'from' => "2020-04-01",
+            'to' => "2021-04-01",
+        ];
+    }
+
+    /**
+     * 獣害情報検索データの生成ができること
+     */
+    public function testMakeEntity01()
+    {
+        /** @var SearchRequest */
+        $req = $this->getValidatedRequest($this->data, SearchRequest::class);
+        $entity = $req->makeEntity();
+        $this->assertSame('テスト', $entity->getQuery());
+        $this->assertEquals(new Carbon('2020-04-01'), $entity->getFrom());
+        $this->assertEquals(new Carbon('2021-04-01'), $entity->getTo());
+    }
+
+    /**
+     * バリデーションが通ること
+     */
+    public function testValidation01()
+    {
+        $actual = $this->getValidateErrors($this->data, SearchRequest::class);
+        $this->assertSame(0, count($actual));
+    }
+
+    /**
+     *  検索文字は空でも良いこと
+     */
+    public function testQuery01()
+    {
+        unset($this->data['query']);
+        $actual = $this->getValidateErrors($this->data, SearchRequest::class);
+        $this->assertSame(0, count($actual));
+    }
+
+    /**
+     *  検索文字は255文字以内であること
+     */
+    public function testQuery02()
+    {
+        // OK
+        $data = array_merge($this->data, [
+            'q' => Str::random(255),
+        ]);
+        $actual = $this->getValidateErrors($data, SearchRequest::class);
+        $this->assertSame(0, count($actual));
+
+        // NG
+        $data = array_merge($this->data, [
+            'q' => Str::random(256),
+        ]);
+        $actual = $this->getValidateErrors($data, SearchRequest::class);
+        $this->assertSame(1, count($actual));
+        $this->assertSame('検索文字は、255文字以下で指定してください。', Arr::get($actual, 'q.0'));
+    }
+
+    /**
+     *  日付(自)は存在しなくても良いこと
+     */
+    public function testFrom01()
+    {
+        unset($this->data['from']);
+        $actual = $this->getValidateErrors($this->data, SearchRequest::class);
+        $this->assertSame(0, count($actual));
+    }
+
+    /**
+     *  日付(自)はY-m-dの日付フォーマットであること
+     */
+    public function testFrom02()
+    {
+        // OK
+        $data = array_merge($this->data, [
+            'from' => "2022-03-01",
+        ]);
+        $actual = $this->getValidateErrors($data, SearchRequest::class);
+        $this->assertSame(0, count($actual));
+
+        // NG
+        $data = array_merge($this->data, [
+            'from' => "2022/03/01",
+        ]);
+        $actual = $this->getValidateErrors($data, SearchRequest::class);
+        $this->assertSame(1, count($actual));
+        $this->assertSame('日付(自)はY-m-d形式で指定してください。', Arr::get($actual, 'from.0'));
+    }
+
+
+    /**
+     *  日付(至)は存在しなくても良いこと
+     */
+    public function testTo01()
+    {
+        unset($this->data['to']);
+        $actual = $this->getValidateErrors($this->data, SearchRequest::class);
+        $this->assertSame(0, count($actual));
+    }
+
+    /**
+     *  日付(至)はY-m-dの日付フォーマットであること
+     */
+    public function testTo02()
+    {
+        // OK
+        $data = array_merge($this->data, [
+            'to' => "2022-03-01",
+        ]);
+        $actual = $this->getValidateErrors($data, SearchRequest::class);
+        $this->assertSame(0, count($actual));
+
+        // NG
+        $data = array_merge($this->data, [
+            'to' => "2022/03/01",
+        ]);
+        $actual = $this->getValidateErrors($data, SearchRequest::class);
+        $this->assertSame(1, count($actual));
+        $this->assertSame('日付(至)はY-m-d形式で指定してください。', Arr::get($actual, 'to.0'));
+    }
+}
+

--- a/api/tests/Unit/UseCases/Matter/ListActionTest.php
+++ b/api/tests/Unit/UseCases/Matter/ListActionTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Unit\UseCases\Matter;
 
 use App\Models\Matter;
+use App\Models\User;
 use App\UseCases\Matter\ListAction;
+use App\UseCases\Matter\ListEntity;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use MatanYadaev\EloquentSpatial\Objects\Point;
 use Tests\TestCase;
 use function count;
@@ -15,9 +18,9 @@ class ListActionTest extends TestCase
 
     /**
      * 害獣情報一覧を取得できること
-     * applied_atの昇順になっていること
+     * applied_atの降順になっていること
      */
-    public function testLest01()
+    public function testList01()
     {
         // テスト準備
         /** @var Matter */
@@ -34,17 +37,225 @@ class ListActionTest extends TestCase
             'applied_at' => "2023-01-01",
         ]);
 
+        // 検索条件
+        $entity = new ListEntity([
+            'query' => '',
+            'from' => null, 
+            'to' => null,
+        ]);
+
         $action = new ListAction();
 
         // テスト実行
         /** @var Matter[] */
-        $results = $action()->get();
+        $results = $action($entity)->get();
 
         // テスト確認
         $this->assertSame(3, count($results));
-        $this->assertSame($matter3->id, $results[0]->id);
+        $this->assertSame($matter2->id, $results[0]->id);
         $this->assertSame($matter1->id, $results[1]->id);
-        $this->assertSame($matter2->id, $results[2]->id);
+        $this->assertSame($matter3->id, $results[2]->id);
+    }
+
+    /**
+     * 害獣情報一覧を取得できること
+     * ユーザ名を部分一致検索で検索できること
+     */
+    public function testUser01()
+    {
+        // テスト準備
+        /** @var Matter */
+        $matter1 = Matter::factory()
+            ->for(User::factory()->state([
+                'name' => 'テスト太郎'
+            ]))
+            ->create([
+                'location' => new Point(131.0, 34.0),
+                'applied_at' => "2023-02-01",
+            ]);
+        /** @var Matter */
+        $matter2 = Matter::factory()
+            ->for(User::factory()->state([
+                'name' => 'ほげほげ次郎'
+            ]))
+            ->create([
+                'location' => new Point(131.0, 34.0),
+                'applied_at' => "2023-02-01",
+            ]);
+        /** @var Matter */
+        $matter3 = Matter::factory()
+            ->for(User::factory()->state([
+                'name' => 'テスト花子'
+            ]))
+            ->create([
+                'location' => new Point(131.0, 34.0),
+                'applied_at' => "2023-02-01",
+            ]);
+
+        $action = new ListAction();
+
+        // 検索条件
+        $entity = new ListEntity([
+            'query' => '郎',
+            'from' => null, 
+            'to' => null,
+        ]);
+
+        // テスト実行
+        /** @var Matter[] */
+        $results = $action($entity)->get();
+
+        // テスト確認
+        // 「郎」で2件ヒット
+        $this->assertSame(2, count($results));
+        $this->assertSame($matter1->id, $results[0]->id);
+        $this->assertSame($matter2->id, $results[1]->id);
+
+        // 検索条件
+        $entity = new ListEntity([
+            'query' => 'テスト',
+            'from' => null, 
+            'to' => null,
+        ]);
+
+        // テスト実行
+        /** @var Matter[] */
+        $results = $action($entity)->get();
+
+        // テスト確認
+        // 「テスト」で2件ヒット
+        $this->assertSame(2, count($results));
+        $this->assertSame($matter1->id, $results[0]->id);
+        $this->assertSame($matter3->id, $results[1]->id);
+    }
+
+    /**
+     * 害獣情報一覧を取得できること
+     * ユーザIDを完全一致検索で検索できること
+     */
+    public function testUser02()
+    {
+        // テスト準備
+        /** @var Matter */
+        $matter = Matter::factory()
+            ->for(User::factory()->state([
+                'name' => 'ほげほげ次郎'
+            ]))
+            ->create([
+                'location' => new Point(131.0, 34.0),
+                'applied_at' => "2023-02-01",
+            ]);
+
+        $action = new ListAction();
+
+        // 検索条件
+        $entity = new ListEntity([
+            'query' => $matter->user_id,
+            'from' => null, 
+            'to' => null,
+        ]);
+
+        // テスト実行
+        /** @var Matter[] */
+        $results = $action($entity)->get();
+
+        // テスト確認
+        // 1件ヒット
+        $this->assertSame(1, count($results));
+        $this->assertSame($matter->id, $results[0]->id);
+
+        // 検索条件
+        $entity = new ListEntity([
+            'query' => substr($matter->user_id, 0, 5), // 部分文字列にする
+            'from' => null, 
+            'to' => null,
+        ]);
+
+        // テスト実行
+        /** @var Matter[] */
+        $results = $action($entity)->get();
+
+        // テスト確認
+        // 0件ヒット
+        $this->assertSame(0, count($results));
+    }
+
+    /**
+     * 害獣情報一覧を取得できること
+     * 日付(自)を指定するとその日付を含んだ以降の獣害情報が取得できること
+     */
+    public function testFrom01() {
+        // テスト準備
+        /** @var Matter */
+        $matter1 = Matter::factory()->create([
+            'location' => new Point(131.0, 34.0),
+            'applied_at' => "2023-02-01",
+        ]);
+        $matter2 = Matter::factory()->create([
+            'location' => new Point(132.0, 35.0),
+            'applied_at' => "2023-03-01",
+        ]);
+        $matter3 = Matter::factory()->create([
+            'location' => new Point(130.0, 34.0),
+            'applied_at' => "2023-01-01",
+        ]);
+
+        // 検索条件
+        $entity = new ListEntity([
+            'query' => '',
+            'from' => new Carbon('2023-02-01'), 
+            'to' => null,
+        ]);
+
+        $action = new ListAction();
+
+        // テスト実行
+        /** @var Matter[] */
+        $results = $action($entity)->get();
+
+        // テスト確認
+        $this->assertSame(2, count($results));
+        $this->assertSame($matter2->id, $results[0]->id);
+        $this->assertSame($matter1->id, $results[1]->id);
+    }
+
+    /**
+     * 害獣情報一覧を取得できること
+     * 日付(至)を指定するとその日付を含んだ以前の獣害情報が取得できること
+     */
+    public function testTo01() {
+        // テスト準備
+        /** @var Matter */
+        $matter1 = Matter::factory()->create([
+            'location' => new Point(131.0, 34.0),
+            'applied_at' => "2023-02-01",
+        ]);
+        $matter2 = Matter::factory()->create([
+            'location' => new Point(132.0, 35.0),
+            'applied_at' => "2023-03-01",
+        ]);
+        $matter3 = Matter::factory()->create([
+            'location' => new Point(130.0, 34.0),
+            'applied_at' => "2023-01-01",
+        ]);
+
+        // 検索条件
+        $entity = new ListEntity([
+            'query' => '',
+            'from' => null, 
+            'to' => new Carbon('2023-02-01'),
+        ]);
+
+        $action = new ListAction();
+
+        // テスト実行
+        /** @var Matter[] */
+        $results = $action($entity)->get();
+
+        // テスト確認
+        $this->assertSame(2, count($results));
+        $this->assertSame($matter1->id, $results[0]->id);
+        $this->assertSame($matter3->id, $results[1]->id);
     }
 }
 

--- a/api/tests/Unit/Utils/StringUtilTest.php
+++ b/api/tests/Unit/Utils/StringUtilTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Utils;
+
+use App\Utils\StringUtil;
+use PHPUnit\Framework\TestCase;
+use function count;
+
+/**
+ * StringUtilのテスト
+ */
+class StringUtilTest extends TestCase
+{
+    /**
+     * startsWithが正しく動作すること
+     */
+    public function testStartsWith01()
+    {
+        $this->assertTrue(StringUtil::startsWith('teststrings', 'test'));
+        $this->assertFalse(StringUtil::startsWith('teststrings', 'strings'));
+        $this->assertFalse(StringUtil::startsWith('test', 'teststrings'));
+        $this->assertTrue(StringUtil::startsWith('テスト文字列', 'テスト'));
+        $this->assertFalse(StringUtil::startsWith('テスト文字列', '文字列'));
+        $this->assertFalse(StringUtil::startsWith('テスト', 'テスト文字列'));
+        $this->assertTrue(StringUtil::startsWith('teststrings', ''));
+    }
+
+    /**
+     * endsWithが正しく動作すること
+     */
+    public function testEndsWith01()
+    {
+        $this->assertFalse(StringUtil::endsWith('teststrings', 'test'));
+        $this->assertTrue(StringUtil::endsWith('teststrings', 'strings'));
+        $this->assertFalse(StringUtil::endsWith('test', 'teststrings'));
+        $this->assertFalse(StringUtil::endsWith('テスト文字列', 'テスト'));
+        $this->assertTrue(StringUtil::endsWith('テスト文字列', '文字列'));
+        $this->assertFalse(StringUtil::endsWith('テスト', 'テスト文字列'));
+        $this->assertTrue(StringUtil::endsWith('teststrings', ''));
+    }
+
+    /**
+     * 半角・全角で区切られた文字列を配列化して返却できること
+     */
+    public function testExplodeWhitespace01()
+    {
+        $test = " 半角 全角　スペース  区切り　";
+        $result = StringUtil::explodeWhitespace($test);
+
+        $this->assertSame(4, count($result));
+        $this->assertSame('半角', $result[0]);
+        $this->assertSame('全角', $result[1]);
+        $this->assertSame('スペース', $result[2]);
+        $this->assertSame('区切り', $result[3]);
+    }
+
+    /**
+     * 重複した文字列がある場合それらは1つに統合されること
+     */
+    public function testExplodeWhitespace02()
+    {
+        $test = "A a B b A b c";
+        $result = StringUtil::explodeWhitespace($test);
+
+        $this->assertSame(5, count($result));
+        $this->assertSame('A', $result[0]);
+        $this->assertSame('a', $result[1]);
+        $this->assertSame('B', $result[2]);
+        $this->assertSame('b', $result[3]);
+        $this->assertSame('c', $result[4]);
+    }
+}

--- a/web/components/consoles/matters/MatterSearch.tsx
+++ b/web/components/consoles/matters/MatterSearch.tsx
@@ -1,0 +1,63 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import InputForm from 'components/atoms/CustomTable'
+import { Condition, searchSchema } from 'hooks/console/matter/useGetMatterPage'
+import React from 'react'
+import { Button, Col, Form, Row } from 'react-bootstrap'
+import { FormProvider, useForm } from 'react-hook-form'
+import { BsSearch } from 'react-icons/bs'
+
+type Props = {
+  condition: Condition
+  onChange?: (condition: Condition) => void
+}
+
+const MatterSearch = (props: Props) => {
+  const form = useForm<Condition>({
+    mode: 'onSubmit',
+    resolver: yupResolver(searchSchema),
+    defaultValues: { ...props.condition },
+  })
+  const { getValues, handleSubmit } = form
+
+  const onChange = () => {
+    props.onChange && props.onChange(getValues())
+  }
+
+  return (
+    <>
+      <Form onSubmit={handleSubmit(onChange)}>
+        <FormProvider {...form}>
+          <Row>
+            <Col sm={6}>
+              <InputForm
+                name='query'
+                placeholder='ユーザー名やユーザーIDで検索'
+                label='文字検索'
+              />
+            </Col>
+            <Col sm={3}>
+              <InputForm type='date' name='from' label='日付(自)' />
+            </Col>
+            <Col sm={3}>
+              <InputForm type='date' name='to' label='日付(至)' />
+            </Col>
+          </Row>
+        </FormProvider>
+        <div className='float-end mt-2'>
+          <Button
+            variant='primary'
+            className='ms-1'
+            onClick={handleSubmit(onChange)}
+          >
+            <span className='d-flex align-items-center'>
+              <BsSearch />
+              検索
+            </span>
+          </Button>
+        </div>
+      </Form>
+    </>
+  )
+}
+
+export default MatterSearch

--- a/web/components/consoles/matters/MatterTable.tsx
+++ b/web/components/consoles/matters/MatterTable.tsx
@@ -1,7 +1,9 @@
 import { ColumnDef } from '@tanstack/react-table'
 import PaginationTable from 'components/atoms/PaginationTable'
 import dayjs from 'dayjs'
-import useGetMatterPage from 'hooks/console/matter/useGetMatterPage'
+import useGetMatterPage, {
+  Condition,
+} from 'hooks/console/matter/useGetMatterPage'
 import useRemoveMatter from 'hooks/console/matter/useRemoveMatter'
 import { Matter } from 'models/Matter'
 import Link from 'next/link'
@@ -10,12 +12,13 @@ import { Button } from 'react-bootstrap'
 import { toast } from 'react-toastify'
 
 type Props = {
+  condition?: Condition
   onRemove?: (matterId: string) => void
 }
 
 const MatterTable = (props: Props) => {
   const [page, setPage] = useState(1)
-  const { data, isLoading, mutate } = useGetMatterPage(page)
+  const { data, isLoading, mutate } = useGetMatterPage(page, props.condition)
   const { execute: executeRemove } = useRemoveMatter()
 
   const onRemove = (matterId: string) => {

--- a/web/hooks/console/matter/useGetMatterPage.ts
+++ b/web/hooks/console/matter/useGetMatterPage.ts
@@ -1,14 +1,30 @@
 import { Pagination } from 'models/Pagination'
 import { Matter } from 'models/Matter'
 import useSWR from 'swr'
+import * as yup from 'yup'
+
+export type Condition = {
+  query: string
+  from: string
+  to: string
+}
+
+export const searchSchema = yup.object<Condition>().shape({
+  query: yup.string().max(255),
+})
 
 /**
  * ページングされた獣害情報を取得する
  */
-const useGetMatterPage = (page: number = 1) => {
+const useGetMatterPage = (page: number = 1, condition?: Condition) => {
   const { data, isLoading, mutate } = useSWR<Pagination<Matter>>(
     '/api/console/matters?' +
-      new URLSearchParams({ page: page.toString() }).toString(),
+      new URLSearchParams({
+        page: page.toString(),
+        query: condition?.query ?? '',
+        from: condition?.from ?? '',
+        to: condition?.to ?? '',
+      }).toString(),
     null,
     {
       keepPreviousData: true,

--- a/web/hooks/console/matter/useGetMatterPage.ts
+++ b/web/hooks/console/matter/useGetMatterPage.ts
@@ -21,7 +21,7 @@ const useGetMatterPage = (page: number = 1, condition?: Condition) => {
     '/api/console/matters?' +
       new URLSearchParams({
         page: page.toString(),
-        query: condition?.query ?? '',
+        q: condition?.query ?? '',
         from: condition?.from ?? '',
         to: condition?.to ?? '',
       }).toString(),

--- a/web/pages/console/matters/index.tsx
+++ b/web/pages/console/matters/index.tsx
@@ -1,10 +1,21 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { NextPageWithLayout } from '_app'
 import Layout from 'components/layouts/ConsoleLayout'
 import MatterTable from 'components/consoles/matters/MatterTable'
 import { Card, Col, Row } from 'react-bootstrap'
+import MatterSearch from 'components/consoles/matters/MatterSearch'
+import { Condition } from 'hooks/console/matter/useGetMatterPage'
 
 const ConsoleMatterList: NextPageWithLayout = () => {
+  const [condition, setCondition] = useState<Condition>({
+    query: '',
+    from: '',
+    to: '',
+  })
+  const onChange = (value: Condition) => {
+    setCondition(value)
+  }
+
   return (
     <>
       <Row>
@@ -15,7 +26,10 @@ const ConsoleMatterList: NextPageWithLayout = () => {
       <Row>
         <Col>
           <Card className='py-3 px-4'>
-            <MatterTable />
+            <div className='pb-3'>
+              <MatterSearch condition={condition} onChange={onChange} />
+            </div>
+            <MatterTable condition={condition} />
           </Card>
         </Col>
       </Row>

--- a/web/pages/console/matters/index.tsx
+++ b/web/pages/console/matters/index.tsx
@@ -26,7 +26,7 @@ const ConsoleMatterList: NextPageWithLayout = () => {
       <Row>
         <Col>
           <Card className='py-3 px-4'>
-            <div className='pb-3'>
+            <div className='pb-4'>
               <MatterSearch condition={condition} onChange={onChange} />
             </div>
             <MatterTable condition={condition} />


### PR DESCRIPTION
# 概要
管理者コンソール画面で、獣害情報一覧を検索できるコンポーネントを作成した。
文字検索では、ユーザ名(部分一致)・ユーザID(完全一致)で検索できるようにした。
日付では、期間を指定して検索できるようになっている。

<img width="1302" alt="image" src="https://user-images.githubusercontent.com/20750714/235293856-d5132685-8251-4822-9448-1046cb4b2fc8.png">

このコンポーネントの追加に伴い、バックエンドにも獣害情報を検索できる機能を追加した。
