### PR TITLE
primaryキーがないテーブルに付いてprimaryキーを付与した

### DIFF
--- a/api/database/migrations/2023_04_30_200920_add_primary_key.php
+++ b/api/database/migrations/2023_04_30_200920_add_primary_key.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('admin_users', function (Blueprint $table) {
+            $table->primary('id');
+        });
+        Schema::table('users', function (Blueprint $table) {
+            $table->primary('id');
+        });
+        Schema::table('matters', function (Blueprint $table) {
+            $table->primary('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('admin_users', function (Blueprint $table) {
+            $table->dropPrimary('PRIMARY');
+        });
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropPrimary('PRIMARY');
+        });
+        Schema::table('matters', function (Blueprint $table) {
+            $table->dropPrimary('PRIMARY');
+        });
+    }
+};


### PR DESCRIPTION
# 概要
プライマリキーが各種テーブルになかったので、プライマリキー属性を付与した
apiコンテナにて
```
php artisan migrate
```
を実行してください。
ロールバックしたいときは、
```
php artisan migrate:rollback
```
でロールバックできます。

# 注意事項
複数idをもつ場合、マイグレーションエラーがでる可能性があります
事前に複数のidを持たないようにDBを適宜作成してください。
(特にデータがなければ、DBデータをフォーマットすることをおすすめします。)