### PR TITLE
closed #71 獣害情報一覧のユーザー名を押すと、そのユーザーの詳細ページに飛べるようにする

### DIFF
--- a/web/components/consoles/matters/MatterDetail.tsx
+++ b/web/components/consoles/matters/MatterDetail.tsx
@@ -49,7 +49,9 @@ const MatterDetail = (props: Props) => {
       <Card className='py-3 px-4'>
         <div>
           <Form.Label>ユーザー名</Form.Label>
-          <div>{props.matter.user?.name}</div>
+          <Link href={`/console/users/${props.matter.user?.id}`}>
+          <p>{props.matter.user?.name}</p>
+          </Link>
         </div>
         <Form onSubmit={handleSubmit(onUpdate)}>
           <FormProvider {...form}>

--- a/web/components/consoles/matters/MatterTable.tsx
+++ b/web/components/consoles/matters/MatterTable.tsx
@@ -45,9 +45,21 @@ const MatterTable = (props: Props) => {
         header: 'ユーザー',
         enableSorting: false,
         cell: (v) => {
-          return v.row.original.user?.name
+          return (
+            <Link href={`/console/users/${v.row.original.user?.id}`}>
+              {v.row.original.user?.name}
+            </Link>
+          )
         },
       },
+      // {
+      //   accessorKey: 'user',
+      //   header: 'ユーザー',
+      //   enableSorting: false,
+      //   cell: (v) => {
+      //     return v.row.original.user?.name
+      //   },
+      // },
       {
         accessorKey: 'lat',
         header: '緯度',

--- a/web/components/consoles/matters/MatterTable.tsx
+++ b/web/components/consoles/matters/MatterTable.tsx
@@ -52,14 +52,6 @@ const MatterTable = (props: Props) => {
           )
         },
       },
-      // {
-      //   accessorKey: 'user',
-      //   header: 'ユーザー',
-      //   enableSorting: false,
-      //   cell: (v) => {
-      //     return v.row.original.user?.name
-      //   },
-      // },
       {
         accessorKey: 'lat',
         header: '緯度',


### PR DESCRIPTION
# 画面
![スクリーンショット 2023-05-04 23 28 37](https://user-images.githubusercontent.com/43633900/236238540-727263a4-82b9-4332-a2b6-bce3a516d98a.png)
獣害情報一覧のユーザー名の部分ホバーすると色が変わります。
押すと、ユーザー詳細画面にジャンプできます。

![スクリーンショット 2023-05-05 10 54 19](https://user-images.githubusercontent.com/43633900/236363153-5889d595-392f-4795-9c0f-b9ccd0a9e284.png)

同様に
獣害情報詳細ページのユーザー名にもリンクを設置しました。

フロントのビルドは成功しています。