### PR TITLE
closed #56 詳細ページの削除に確認ダイアログを作成する

### DIFF
--- a/web/components/consoles/matters/MatterDetail.tsx
+++ b/web/components/consoles/matters/MatterDetail.tsx
@@ -1,13 +1,17 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import useRemoveMatter from 'hooks/console/matter/useRemoveMatter'
-import useUpdateMatter, { matterSchema, UpdateMatterForm } from 'hooks/console/matter/useUpdateMatter'
+import useUpdateMatter, {
+  matterSchema,
+  UpdateMatterForm,
+} from 'hooks/console/matter/useUpdateMatter'
 import { Matter } from 'models/Matter'
 import Link from 'next/link'
-import React from 'react'
+import React, { useState } from 'react'
 import { Button, Card, Form } from 'react-bootstrap'
 import { FormProvider, useForm } from 'react-hook-form'
 import { toast } from 'react-toastify'
 import MatterForm from './MatterForm'
+import AlertDialog from 'components/molecules/AlertDialog'
 
 type Props = {
   matter: Matter
@@ -34,7 +38,7 @@ const MatterDetail = (props: Props) => {
       props.onUpdate && props.onUpdate()
     })
   }
-
+  const [visible, setVisible] = useState(false)
   const onRemove = () => {
     executeRemove(props.matter.id).then(() => {
       toast.success('獣害情報を削除しました。')
@@ -50,7 +54,7 @@ const MatterDetail = (props: Props) => {
         <div>
           <Form.Label>ユーザー名</Form.Label>
           <Link href={`/console/users/${props.matter.user?.id}`}>
-          <p>{props.matter.user?.name}</p>
+            <p>{props.matter.user?.name}</p>
           </Link>
         </div>
         <Form onSubmit={handleSubmit(onUpdate)}>
@@ -63,14 +67,21 @@ const MatterDetail = (props: Props) => {
                 一覧に戻る
               </Button>
             </Link>
-            <Button
-              variant='danger'
-              className='ms-1'
-              onClick={onRemove}
-              disabled={loading}
+            <span className='ms-1'>
+              <Button variant='danger' onClick={() => setVisible(!visible)}>
+                削除
+              </Button>
+            </span>
+            <AlertDialog
+              show={visible}
+              title='確認'
+              confirmText='削除'
+              confirmColor='danger'
+              onConfirm={onRemove}
+              onCancel={() => setVisible(false)}
             >
-              削除
-            </Button>
+              この獣害情報を削除します。操作はもとに戻せません。
+            </AlertDialog>
             <Button
               variant='primary'
               className='ms-1'

--- a/web/components/consoles/users/UserDetail.tsx
+++ b/web/components/consoles/users/UserDetail.tsx
@@ -40,7 +40,6 @@ const UserDetail = (props: Props) => {
   }
 
   const loading = loadingUpdate || loadingRemove
-
   // 削除関連
   const [visible, setVisible] = useState(false)
   const onRemove = () => {

--- a/web/components/consoles/users/UserDetail.tsx
+++ b/web/components/consoles/users/UserDetail.tsx
@@ -85,7 +85,7 @@ const UserDetail = (props: Props) => {
               onConfirm={onRemove}
               onCancel={() => setVisible(false)}
             >
-              ユーザーを削除します。この操作はもとに戻せません。
+              このユーザーを削除します。操作はもとに戻せません。
             </AlertDialog>
             <Button
               variant='primary'

--- a/web/components/consoles/users/UserDetail.tsx
+++ b/web/components/consoles/users/UserDetail.tsx
@@ -6,11 +6,12 @@ import useUpdateUser, {
 } from 'hooks/console/user/useUpdateUser'
 import { User } from 'models/User'
 import Link from 'next/link'
-import React from 'react'
+import React, { useState } from 'react'
 import { Button, Card, Form } from 'react-bootstrap'
 import { FormProvider, useForm } from 'react-hook-form'
 import { toast } from 'react-toastify'
 import UserForm from './UserForm'
+import AlertDialog from 'components/molecules/AlertDialog'
 
 type Props = {
   user: User
@@ -38,14 +39,16 @@ const UserDetail = (props: Props) => {
     })
   }
 
+  const loading = loadingUpdate || loadingRemove
+
+  // 削除関連
+  const [visible, setVisible] = useState(false)
   const onRemove = () => {
     executeRemove(props.user.id).then((_) => {
       toast.success('ユーザー情報を削除しました。')
       props.onRemove && props.onRemove()
     })
   }
-
-  const loading = loadingUpdate || loadingRemove
 
   return (
     <>
@@ -69,14 +72,30 @@ const UserDetail = (props: Props) => {
                 一覧に戻る
               </Button>
             </Link>
-            <Button
+            {/* <Button
               variant='danger'
               className='ms-1'
               onClick={onRemove}
               disabled={loading}
             >
               削除
-            </Button>
+            </Button> */}
+            <span className='ms-1'>
+              <Button variant='danger' onClick={() => setVisible(!visible)}>
+                削除
+              </Button>
+            </span>
+            <AlertDialog
+              show={visible}
+              title='確認'
+              confirmText='削除'
+              confirmColor='danger'
+              // loading={loading}
+              onConfirm={onRemove}
+              onCancel={() => setVisible(false)}
+            >
+              ユーザーを削除します。この操作はもとに戻せません。
+            </AlertDialog>
             <Button
               variant='primary'
               className='ms-1'

--- a/web/components/consoles/users/UserDetail.tsx
+++ b/web/components/consoles/users/UserDetail.tsx
@@ -72,14 +72,6 @@ const UserDetail = (props: Props) => {
                 一覧に戻る
               </Button>
             </Link>
-            {/* <Button
-              variant='danger'
-              className='ms-1'
-              onClick={onRemove}
-              disabled={loading}
-            >
-              削除
-            </Button> */}
             <span className='ms-1'>
               <Button variant='danger' onClick={() => setVisible(!visible)}>
                 削除
@@ -90,7 +82,6 @@ const UserDetail = (props: Props) => {
               title='確認'
               confirmText='削除'
               confirmColor='danger'
-              // loading={loading}
               onConfirm={onRemove}
               onCancel={() => setVisible(false)}
             >

--- a/web/components/consoles/users/UserTable.tsx
+++ b/web/components/consoles/users/UserTable.tsx
@@ -43,7 +43,6 @@ const UserTable = (props: Props) => {
         enableSorting: false,
         cell: (value) => {
           const userId = value.row.original.id
-
           return (
             <>
               <Link href={`/console/users/${userId}`}>

--- a/web/components/consoles/users/UserTable.tsx
+++ b/web/components/consoles/users/UserTable.tsx
@@ -1,5 +1,7 @@
 import { ColumnDef } from '@tanstack/react-table'
 import PaginationTable from 'components/atoms/PaginationTable'
+import AlertDialog from 'components/molecules/AlertDialog'
+import { log } from 'console'
 import useGetUserPage, { Condition } from 'hooks/console/user/useGetUserPage'
 import useRemoveUser from 'hooks/console/user/useRemoveUser'
 import { User } from 'models/User'
@@ -18,6 +20,7 @@ const UserTable = (props: Props) => {
   const { data, isLoading, mutate } = useGetUserPage(page, props.condition)
   const { execute: executeRemove } = useRemoveUser()
 
+  const [visible, setVisible] = useState(false)
   const onRemove = (userId: string) => {
     executeRemove(userId).then((_) => {
       // 削除後にユーザー情報一覧を再取得する
@@ -43,6 +46,7 @@ const UserTable = (props: Props) => {
         enableSorting: false,
         cell: (value) => {
           const userId = value.row.original.id
+
           return (
             <>
               <Link href={`/console/users/${userId}`}>
@@ -50,14 +54,34 @@ const UserTable = (props: Props) => {
                   詳細
                 </Button>
               </Link>
-              <Button
+              {/* <Button
                 size='sm'
                 variant='danger'
                 className='mx-1'
                 onClick={() => onRemove(userId)}
               >
                 削除
-              </Button>
+              </Button> */}
+              <span className='ms-1'>
+                <Button
+                  variant='danger'
+                  size='sm'
+                  onClick={() => setVisible(!visible)}
+                  // onClick={() => onRemove(userId)}
+                >
+                  削除
+                </Button>
+              </span>
+              <AlertDialog
+                show={visible}
+                title='確認'
+                confirmText='削除'
+                confirmColor='danger'
+                onConfirm={() => onRemove(userId)}
+                onCancel={() => setVisible(false)}
+              >
+                ユーザーを削除します。この操作はもとに戻せません。
+              </AlertDialog>
             </>
           )
         },

--- a/web/components/consoles/users/UserTable.tsx
+++ b/web/components/consoles/users/UserTable.tsx
@@ -1,7 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table'
 import PaginationTable from 'components/atoms/PaginationTable'
-import AlertDialog from 'components/molecules/AlertDialog'
-import { log } from 'console'
 import useGetUserPage, { Condition } from 'hooks/console/user/useGetUserPage'
 import useRemoveUser from 'hooks/console/user/useRemoveUser'
 import { User } from 'models/User'
@@ -20,7 +18,6 @@ const UserTable = (props: Props) => {
   const { data, isLoading, mutate } = useGetUserPage(page, props.condition)
   const { execute: executeRemove } = useRemoveUser()
 
-  const [visible, setVisible] = useState(false)
   const onRemove = (userId: string) => {
     executeRemove(userId).then((_) => {
       // 削除後にユーザー情報一覧を再取得する
@@ -54,34 +51,14 @@ const UserTable = (props: Props) => {
                   詳細
                 </Button>
               </Link>
-              {/* <Button
+              <Button
                 size='sm'
                 variant='danger'
                 className='mx-1'
                 onClick={() => onRemove(userId)}
               >
                 削除
-              </Button> */}
-              <span className='ms-1'>
-                <Button
-                  variant='danger'
-                  size='sm'
-                  onClick={() => setVisible(!visible)}
-                  // onClick={() => onRemove(userId)}
-                >
-                  削除
-                </Button>
-              </span>
-              <AlertDialog
-                show={visible}
-                title='確認'
-                confirmText='削除'
-                confirmColor='danger'
-                onConfirm={() => onRemove(userId)}
-                onCancel={() => setVisible(false)}
-              >
-                ユーザーを削除します。この操作はもとに戻せません。
-              </AlertDialog>
+              </Button>
             </>
           )
         },

--- a/web/components/molecules/AlertDialog.tsx
+++ b/web/components/molecules/AlertDialog.tsx
@@ -34,7 +34,7 @@ const AlertDialog = (props: Props) => {
           onHide={props.onCancel}
           className='py-2'
         >
-          <div className='h3 my-auto'  style={{ color: '#dc3545' }}>
+          <div className='my-auto'>
             {props.title ? props.title : ''}
           </div>
         </Modal.Header>

--- a/web/components/molecules/AlertDialog.tsx
+++ b/web/components/molecules/AlertDialog.tsx
@@ -34,7 +34,7 @@ const AlertDialog = (props: Props) => {
           onHide={props.onCancel}
           className='py-2'
         >
-          <div className='h3 my-auto'>
+          <div className='h3 my-auto'  style={{ color: '#dc3545' }}>
             {props.title ? props.title : ''}
           </div>
         </Modal.Header>

--- a/web/components/molecules/AlertDialog.tsx
+++ b/web/components/molecules/AlertDialog.tsx
@@ -4,7 +4,6 @@ import ConfirmAndCancel from './ConfirmAndCancel'
 
 interface Props {
   show: boolean
-  // size?: 'sm' | 'lg' | 'xl'
   title?: string
   loading?: boolean
   children?: ReactNode
@@ -27,9 +26,6 @@ const AlertDialog = (props: Props) => {
         centered
         backdrop='static'
         show={props.show}
-        // size={props.size}
-        // dialogClassName='niokuru-dialog'
-        // contentClassName='niokuru-dialog-content'
       >
         <Modal.Header
           closeButton

--- a/web/components/molecules/AlertDialog.tsx
+++ b/web/components/molecules/AlertDialog.tsx
@@ -1,0 +1,60 @@
+import { Modal } from 'react-bootstrap'
+import { ReactNode } from 'react'
+import ConfirmAndCancel from './ConfirmAndCancel'
+
+interface Props {
+  show: boolean
+  // size?: 'sm' | 'lg' | 'xl'
+  title?: string
+  loading?: boolean
+  children?: ReactNode
+  confirmText?: string
+  confirmColor?: string
+  cancelText?: string
+  onConfirm?: () => void
+  onCancel?: () => void
+}
+
+/**
+ * このダイアログはユーザの操作を強制的にフォーカスします。
+ * フォームなどの入力目的には利用せず、
+ * 削除確認など、不可逆的な操作を行う際の確認として利用してください。
+ */
+const AlertDialog = (props: Props) => {
+  return (
+    <>
+      <Modal
+        centered
+        backdrop='static'
+        show={props.show}
+        // size={props.size}
+        // dialogClassName='niokuru-dialog'
+        // contentClassName='niokuru-dialog-content'
+      >
+        <Modal.Header
+          closeButton
+          closeLabel='閉じる'
+          closeVariant='white'
+          onHide={props.onCancel}
+          className='py-2'
+        >
+          <div className='h3 my-auto'>
+            {props.title ? props.title : ''}
+          </div>
+        </Modal.Header>
+        <Modal.Body className='py-2 px-4'>{props.children}</Modal.Body>
+        <Modal.Footer className='pt-0 pb-2' style={{ borderTopWidth: 0 }}>
+          <ConfirmAndCancel
+            confirmText={props.confirmText ? props.confirmText : 'OK'}
+            confirmColor={props.confirmColor ? props.confirmColor : 'primary'}
+            cancelText={props.cancelText ? props.cancelText : 'キャンセル'}
+            onConfirm={props.onConfirm}
+            onCancel={props.onCancel}
+          />
+        </Modal.Footer>
+      </Modal>
+    </>
+  )
+}
+
+export default AlertDialog

--- a/web/components/molecules/ConfirmAndCancel.tsx
+++ b/web/components/molecules/ConfirmAndCancel.tsx
@@ -25,7 +25,7 @@ const ConfirmAndCancel = (props: Props) => {
         {props.cancelText ?? 'キャンセル'}
       </Button>
       <Button
-        color={props.confirmColor}
+        variant={props.confirmColor}
         disabled={props.disabled}
         onClick={props.onConfirm}
       >

--- a/web/components/molecules/ConfirmAndCancel.tsx
+++ b/web/components/molecules/ConfirmAndCancel.tsx
@@ -1,0 +1,38 @@
+import { Button } from 'react-bootstrap'
+
+interface Props {
+  confirmText: string
+  confirmColor?: string
+  cancelText?: string
+  disabled?: boolean
+  onConfirm?: () => void
+  onCancel?: () => void
+}
+
+/**
+ * 確認とキャンセルが含まれるボタン
+ * 主にダイアログで使用する
+ */
+const ConfirmAndCancel = (props: Props) => {
+  return (
+    <>
+      <Button
+        className='me-2'
+        color='secondary'
+        variant='ghost'
+        onClick={props.onCancel}
+      >
+        {props.cancelText ?? 'キャンセル'}
+      </Button>
+      <Button
+        color={props.confirmColor}
+        disabled={props.disabled}
+        onClick={props.onConfirm}
+      >
+        {props.confirmText}
+      </Button>
+    </>
+  )
+}
+
+export default ConfirmAndCancel


### PR DESCRIPTION
いつでも結構ですので、レビューをお願いいたします。

#対応ブランチ
#56 

※
一覧（テーブル）にある削除ボタンを押した時に確認用のモーダルwindowが出るようにするのは、別issueにしたいと思います。

とりあえず、詳細画面の削除ボタンを押すとモーダルが出現するようにしました。（一覧の削除ボタンでモーダルを出すのに手こずりましたので、、、）

フロントビルドは成功しています。

＜＜ ユーザー詳細の削除ボタンを押した場合 ＞＞
![スクリーンショット 2023-05-05 21 09 48](https://user-images.githubusercontent.com/43633900/236593989-b31e3320-787e-4295-b30d-e08aaed76b18.png)

＜＜ 獣害情報詳細の削除ボタンを押した場合 ＞＞
![スクリーンショット 2023-05-06 13 30 40](https://user-images.githubusercontent.com/43633900/236599969-9d641c6c-db11-48f9-bf45-6ec0bdef8604.png)