### PR TITLE
close #75 ページネーションできる表に選択機能を追加した

### DIFF
--- a/web/components/atoms/PaginationTable.tsx
+++ b/web/components/atoms/PaginationTable.tsx
@@ -11,9 +11,10 @@ import {
 } from '@tanstack/react-table'
 import { Pagination } from 'models/Pagination'
 import { CSSProperties, useEffect, useMemo, useState } from 'react'
-import { FormCheck, Table } from 'react-bootstrap'
+import { Table } from 'react-bootstrap'
 import PaginationLink from './PaginationLink'
 import { BsSortDown, BsSortUp } from 'react-icons/bs'
+import Checkbox from 'react-three-state-checkbox'
 
 declare module '@tanstack/table-core' {
   interface ColumnMeta<TData, TValue> {
@@ -50,15 +51,16 @@ const PaginationTable = <T extends object>(props: Props<T>) => {
         id: '__select__',
         header: (v) => (
           <div className='text-center'>
-            <FormCheck
+            <Checkbox
               checked={v.table.getIsAllRowsSelected()}
+              indeterminate={v.table.getIsSomeRowsSelected()}
               onChange={v.table.getToggleAllRowsSelectedHandler()}
             />
           </div>
         ),
         cell: (v) => (
           <div className='text-center'>
-            <FormCheck
+            <Checkbox
               checked={v.row.getIsSelected()}
               onChange={v.row.getToggleSelectedHandler()}
             />

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "react-geolocated": "^4.0.3",
     "react-hook-form": "^7.43.2",
     "react-icons": "^4.8.0",
+    "react-three-state-checkbox": "^3.0.0",
     "react-toastify": "^9.1.2",
     "swr": "^2.0.4",
     "yup": "^1.1.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2692,6 +2692,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-three-state-checkbox@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-three-state-checkbox/-/react-three-state-checkbox-3.0.0.tgz#38997453093f9e0b6725165497d45cb16991ed4b"
+  integrity sha512-siWkrmaSTokUSgU3LISdnHbbX4Ignnvo85YhJrKtIs/9H+KnOWfsmmg4NnWnhWd+mj5Cca91gQVcDGKtH++T9Q==
+
 react-toastify@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.2.tgz#293aa1f952240129fe485ae5cb2f8d09c652cf3f"


### PR DESCRIPTION
# 概要
ページネーションできる表に選択機能を追加しました。
現在、選択機能を使う機能は無いので、機能だけの提供になります。
(MatterTableやUserTableで実装はしていません。)

# 変更内容
`PaginationTable`に`selectMode`プロパティを追加しました。
`selectMode`が`true`の場合、テーブルの左端列にチェックボックスが追加されます。
<img width="752" alt="image" src="https://user-images.githubusercontent.com/20750714/236671942-f5a48512-8bb9-4a27-af84-8998f3c0fccb.png">

ヘッダ列をクリックすると、全選択・全解除が可能です。
<img width="752" alt="image" src="https://user-images.githubusercontent.com/20750714/236672044-b20fde87-e379-43ab-b00d-8d1eb832e9e4.png">

ヘッダ列のチェックボックスは、不完全な状態をとることもあります。
(各行のチェックがあったりなかったりする場合)
<img width="752" alt="image" src="https://user-images.githubusercontent.com/20750714/236672069-1b8718c9-dc34-406c-b092-8b2ef2b4989c.png">

`onChangeSelects`プロパティで、選択が変更された時にチェックされたモデルのIDリストを取得することができます。
<img width="482" alt="image" src="https://user-images.githubusercontent.com/20750714/236672176-602e3432-299f-4772-adb5-cf2288904e45.png">


