### PR TITLE
closed #95 通常ユーザー用の獣害情報詳細画面を作成した

### DIFF
--- a/api/app/Http/Controllers/MatterController.php
+++ b/api/app/Http/Controllers/MatterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\Matter\CreateRequest;
 use App\Http\Resources\MatterResource;
+use App\Models\Matter;
 use App\UseCases\Matter\CreateAction;
 use App\UseCases\Matter\ListAction;
 
@@ -27,5 +28,14 @@ class MatterController extends Controller
         $user = $req->makeUser();
         $matter = $action($entity, $user);
         return response()->json(new MatterResource($matter), 201);
+    }
+
+    /**
+     * 害獣情報詳細
+     */
+    public function detail(Matter $matter)
+    {
+        $matter->load(['user']);
+        return response()->json(new MatterResource($matter), 200);
     }
 }

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -76,6 +76,9 @@ Route::prefix('console')->group(function () {
 Route::get('matters', [MatterController::class, 'index']);
 // 害獣情報作成
 Route::post('matters', [MatterController::class, 'create']);
+// 害獣情報詳細
+Route::get('matters/{matter}', [MatterController::class, 'detail'])
+    ->whereUlid('matter');
 
 // ユーザ確認
 Route::get('users/{userId}/verify', [UserController::class, 'verify'])

--- a/api/tests/Feature/Http/Controllers/MatterControllerTest.php
+++ b/api/tests/Feature/Http/Controllers/MatterControllerTest.php
@@ -69,4 +69,21 @@ class MatterControllerTest extends ControllerTestCase
         // ステータスコードの検証
         $response->assertStatus(201); // 201 Cerated
     }
+
+    /**
+     * 獣害情報を取得できること
+     */
+    public function testDetail()
+    {
+        // テスト準備
+        $matter = Matter::factory()->create();
+
+        // テスト実行
+        // リクエストを送信する
+        $response = $this->getJson("api/matters/{$matter->id}");
+
+        // テスト確認
+        // ステータスコードの検証
+        $response->assertStatus(200);
+    }
 }

--- a/web/components/layouts/MenuLayout.tsx
+++ b/web/components/layouts/MenuLayout.tsx
@@ -13,7 +13,6 @@ const MenuLayout = ({ children }: LayoutProps) => (
     <Navbar bg='light' expand='lg'>
       <Container>
         <Navbar.Brand>小野地区獣害マップ</Navbar.Brand>
-        <Navbar.Toggle aria-controls='basic-navbar-nav' />
       </Container>
     </Navbar>
     <Container className='my-2'>{children}</Container>

--- a/web/components/maps/MarkerMap.tsx
+++ b/web/components/maps/MarkerMap.tsx
@@ -1,0 +1,49 @@
+import DeckGLMap from 'components/atoms/DeckGLMap'
+import { IconLayer } from '@deck.gl/layers/typed'
+import { LatLng } from 'models/LatLng'
+
+type Props = {
+  latLng: LatLng
+  width?: string
+  height?: string
+}
+
+const ICON_MAPPING = {
+  marker: { x: 0, y: 0, width: 64, height: 64, anchorY: 64 },
+}
+
+/**
+ * マーカーマップを表示できるマップ
+ */
+const MarkerMap = (props: Props) => {
+  const iconLayer = new IconLayer<[number, number]>({
+    id: 'icon-layer',
+    data: [[props.latLng.lng, props.latLng.lat]],
+    iconAtlas: '/image/marker.png',
+    iconMapping: ICON_MAPPING,
+    getIcon: (_) => 'marker',
+    sizeScale: 1,
+    getPosition: (d) => d,
+    getSize: (_) => 32,
+  })
+
+  return (
+    <DeckGLMap
+      layers={[iconLayer]}
+      style={{
+        width: props.width ? props.width : '100%',
+        height: props.height ? props.height : '300px',
+        position: 'relative',
+      }}
+      initialViewState={{
+        longitude: props.latLng.lng,
+        latitude: props.latLng.lat,
+        zoom: 16,
+        pitch: 0,
+        bearing: 0,
+      }}
+    />
+  )
+}
+
+export default MarkerMap

--- a/web/components/matters/MatterRegister.tsx
+++ b/web/components/matters/MatterRegister.tsx
@@ -11,7 +11,7 @@ type Props = {
   onCreate?: () => void
 }
 
-const MatterDetail = (props: Props) => {
+const MatterRegister = (props: Props) => {
   const form = useForm<AddMatterForm>({
     mode: 'onSubmit',
     defaultValues: {
@@ -59,4 +59,4 @@ const MatterDetail = (props: Props) => {
   )
 }
 
-export default MatterDetail
+export default MatterRegister

--- a/web/hooks/matter/useGetMatter.tsx
+++ b/web/hooks/matter/useGetMatter.tsx
@@ -1,0 +1,23 @@
+import { Matter } from 'models/Matter'
+import useSWR from 'swr'
+
+/**
+ * 獣害情報を取得する
+ * @param id 獣害情報ID
+ */
+const useGetMatter = (id?: string) => {
+  const { data, isLoading, mutate } = useSWR<Matter>(
+    id ? `/api/matters/${id}` : undefined,
+    null,
+    {
+      keepPreviousData: true,
+    },
+  )
+  return {
+    data,
+    mutate,
+    isLoading,
+  }
+}
+
+export default useGetMatter

--- a/web/pages/matters/[matterId].tsx
+++ b/web/pages/matters/[matterId].tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { NextPageWithLayout } from '_app'
+import Layout from 'components/layouts/MenuLayout'
+import { Card, Col, Form, Row, Spinner } from 'react-bootstrap'
+
+import { useRouter } from 'next/router'
+import MarkerMap from 'components/maps/MarkerMap'
+import useGetMatter from 'hooks/matter/useGetMatter'
+import dayjs, { Dayjs } from 'dayjs'
+
+const MatterDetail: NextPageWithLayout = () => {
+  const router = useRouter()
+  const { matterId } = router.query
+  const { data } = useGetMatter(matterId as string | undefined)
+
+  const getDateFormat = (date: Dayjs) => {
+    return date.format('YYYY年M月D日')
+  }
+
+  return (
+    <>
+      <Row>
+        <Col>
+          <h3>獣害情報詳細</h3>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Card className='py-3 px-4'>
+            {data ? (
+              <div>
+                <Form.Label>ユーザー名</Form.Label>
+                <p>{data.user?.name}</p>
+                <Form.Label>日付</Form.Label>
+                <p>{getDateFormat(dayjs(data.appliedAt))}</p>
+                <MarkerMap latLng={data?.latLng} />
+              </div>
+            ) : (
+              <div
+                className='d-flex align-items-center justify-content-center'
+                style={{ height: 426 }}
+              >
+                <Spinner animation='border' role='status'>
+                  <span className='visually-hidden'>Loading...</span>
+                </Spinner>
+              </div>
+            )}
+          </Card>
+        </Col>
+      </Row>
+    </>
+  )
+}
+
+MatterDetail.getLayout = function getLayout(page) {
+  return <Layout>{page}</Layout>
+}
+
+export default MatterDetail

--- a/web/pages/users/[userId]/report.tsx
+++ b/web/pages/users/[userId]/report.tsx
@@ -7,7 +7,7 @@ import { NextPageWithLayout } from '_app'
 import { useRouter } from 'next/router'
 import useVerifyUser from 'hooks/user/useVerifyUser'
 import { LatLng } from 'models/LatLng'
-import MatterDetail from 'components/matters/MatterDetail'
+import MatterRegister from 'components/matters/MatterRegister'
 
 const Report: NextPageWithLayout = () => {
   const [location, setLocation] = useState<LatLng>()
@@ -72,7 +72,7 @@ const Report: NextPageWithLayout = () => {
         <Col>
           <Card className='py-3 px-4'>
             {location && userId ? (
-              <MatterDetail initLatLng={location} userId={userId as string} />
+              <MatterRegister initLatLng={location} userId={userId as string} />
             ) : (
               <div
                 className='d-flex align-items-center justify-content-center'


### PR DESCRIPTION
# 概要
獣害情報詳細画面を作成した。
獣害情報1つに注目し、その詳細情報が見えるようにした。
この獣害情報詳細画面は、ユーザに関わらず、閲覧できる

URLは`matters/{matterId}`で取得できる。
<img width="746" alt="image" src="https://github.com/gunsow911/ono_hackathon_saru/assets/20750714/51eb6314-7bc3-469f-a3d9-cde2ec169d75">
