### PR TITLE
closed #102 獣害報告画面を全画面に変更し、報告結果をトーストで表現するようにした

### DIFF
--- a/web/components/atoms/LatLngMapForm.tsx
+++ b/web/components/atoms/LatLngMapForm.tsx
@@ -12,8 +12,6 @@ const ICON_MAPPING = {
 type Props = {
   name: string
   label?: string
-  width?: string
-  height?: string
 }
 
 /**
@@ -55,9 +53,8 @@ const LatLngMapForm = (props: Props) => {
         <DeckGLMap
           layers={[iconLayer]}
           style={{
-            width: props.width ? props.width : '400px',
-            height: props.height ? props.height : '300px',
-            position: 'relative',
+            height: '100%',
+            position: 'absolute',
           }}
           initialViewState={{
             longitude: initLatLng.lng,

--- a/web/components/consoles/matters/MatterForm.tsx
+++ b/web/components/consoles/matters/MatterForm.tsx
@@ -10,7 +10,9 @@ const MatterForm = () => {
         <InputForm type='date' name='appliedAt' label='日付' />
       </Form.Group>
       <Form.Group className='py-2'>
-        <LatLngMapForm width='100%' name='latLng' label='位置情報' />
+        <div style={{ height: '300px', position: 'relative' }}>
+          <LatLngMapForm name='latLng' label='位置情報' />
+        </div>
       </Form.Group>
     </>
   )

--- a/web/components/matters/MatterForm.tsx
+++ b/web/components/matters/MatterForm.tsx
@@ -4,11 +4,11 @@ import { Form } from 'react-bootstrap'
 
 const MatterForm = () => {
   return (
-    <>
-      <Form.Group className='py-2'>
-        <LatLngMapForm width='100%' name='latLng' />
-      </Form.Group>
-    </>
+    <Form.Group>
+      <div className='fullscreen-map' style={{ position: 'relative' }}>
+        <LatLngMapForm name='latLng' />
+      </div>
+    </Form.Group>
   )
 }
 

--- a/web/components/matters/MatterRegister.tsx
+++ b/web/components/matters/MatterRegister.tsx
@@ -1,8 +1,9 @@
 import useAddMatter, { AddMatterForm } from 'hooks/matter/useAddMatter'
 import { LatLng } from 'models/LatLng'
-import React, { ReactNode } from 'react'
-import { Alert, Button, Form } from 'react-bootstrap'
+import React, { useState } from 'react'
+import { Button, Form } from 'react-bootstrap'
 import { FormProvider, useForm } from 'react-hook-form'
+import { toast } from 'react-toastify'
 import MatterForm from './MatterForm'
 
 type Props = {
@@ -19,42 +20,51 @@ const MatterRegister = (props: Props) => {
     },
   })
   const { getValues, handleSubmit } = form
-  const { data, execute, loading, error } = useAddMatter()
+  const { execute, loading } = useAddMatter()
+  const [isToastEmpty, setIsToastEmpty] = useState<boolean>(true)
+
+  toast.onChange((item) => {
+    const isActive = toast.isActive(item.id)
+    setIsToastEmpty(!isActive)
+  })
 
   const onCreate = () => {
-    execute(props.userId, getValues()).then(() => {
-      props.onCreate && props.onCreate()
-    })
-  }
-
-  const showResult = (): ReactNode => {
-    if (data && error !== null) {
-      return (
-        <Alert variant='danger'>
-          報告に失敗しました。インターネットの接続や位置情報の設定がオンであることを確かめてください。
-        </Alert>
+    if (isToastEmpty) {
+      execute(props.userId, getValues()).then(
+        () => {
+          const id = toast.success('報告が完了しました！')
+          props.onCreate && props.onCreate()
+        },
+        () => {
+          const id = toast.error(
+            <>
+              <div>報告に失敗しました。</div>
+              <div>
+                インターネットの接続や位置情報の設定がオンであることを確かめてください。
+              </div>
+            </>,
+          )
+        },
       )
     }
-    if (data && !loading) {
-      return <Alert variant='success'>報告が完了しました！</Alert>
-    }
-    return <></>
   }
 
   return (
     <>
-      <div className='text-center'>獣害を受けた場所を選択してください</div>
+      <div className='text-center mb-2'>獣害を受けた場所を選択してください</div>
       <Form onSubmit={handleSubmit(onCreate)}>
         <FormProvider {...form}>
           <MatterForm />
         </FormProvider>
         <div className='d-flex justify-content-center pt-2'>
-          <Button disabled={loading} onClick={handleSubmit(onCreate)}>
+          <Button
+            disabled={loading || !isToastEmpty}
+            onClick={handleSubmit(onCreate)}
+          >
             {loading ? <>報告中…</> : <>獣害報告！</>}
           </Button>
         </div>
       </Form>
-      <div className='pt-2'>{showResult()}</div>
     </>
   )
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -18,16 +18,18 @@ const Home: NextPageWithLayout = () => {
   const { data } = useListMatter(between)
 
   return (
-    <div className='fullscreen-map' style={{ position: 'relative' }}>
-      <HeatmapMap
-        data={data}
-        initLatLng={{ lat: 34.1046934, lng: 131.3046877 }}
-        getPosition={(data) => {
-          return [data.latLng.lng, data.latLng.lat]
-        }}
-      >
-        <TimeScale onChange={setBetween} />
-      </HeatmapMap>
+    <div className='main'>
+      <div className='fullscreen-map' style={{ position: 'relative' }}>
+        <HeatmapMap
+          data={data}
+          initLatLng={{ lat: 34.1046934, lng: 131.3046877 }}
+          getPosition={(data) => {
+            return [data.latLng.lng, data.latLng.lat]
+          }}
+        >
+          <TimeScale onChange={setBetween} />
+        </HeatmapMap>
+      </div>
     </div>
   )
 }

--- a/web/pages/users/[userId]/report.tsx
+++ b/web/pages/users/[userId]/report.tsx
@@ -84,15 +84,12 @@ const Report: NextPageWithLayout = () => {
       )}
       <Row>
         <Col>
-          <Card className='py-3 px-4'>
+          <Card className='py-3 px-4 report'>
             {location && userId ? (
               <MatterRegister initLatLng={location} userId={userId as string} />
             ) : (
               <>
-                <div
-                  className='d-flex flex-column align-items-center justify-content-center'
-                  style={{ height: 426 }}
-                >
+                <div className='fullscreen-map d-flex flex-column align-items-center justify-content-center'>
                   <div className='my-2'>
                     <Spinner animation='border' role='status'>
                       <span className='visually-hidden'>Loading...</span>

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -32,6 +32,10 @@ a {
   box-shadow: rgba(50, 50, 93, 0.02) 0 2px 5px -1px, rgba(0, 0, 0, 0.05) 0 1px 3px -1px;
 }
 
-.fullscreen-map {
+.main .fullscreen-map {
     height: calc(100dvh - 56px);
+}
+
+.report .fullscreen-map {
+    height: calc(100dvh - 112px - 72px);
 }


### PR DESCRIPTION
# 概要
獣害報告画面を画面いっぱいに変更しました。
また、報告結果を画面上のAlert枠で表示させるのではなく、
トースト(画面の右からのポップアップ)で表現させるようにしました。

このトーストが表示されている間、追加で獣害報告をすることはできません。
これは、連打による重複しての投稿を防ぐ狙いがあります。

約5秒後にトーストが消えて再度獣害報告が可能になりますが、
トーストの削除ボタン(xボタン)をクリックしてトーストを削除することで、それよりも早く再度獣害報告が可能になります。

